### PR TITLE
Document overridden functions

### DIFF
--- a/util/schema-gen/src/org/javarosa/engine/xml/MockupParser.java
+++ b/util/schema-gen/src/org/javarosa/engine/xml/MockupParser.java
@@ -24,6 +24,10 @@ public class MockupParser extends ElementParser<Mockup> {
 		super(suiteStream);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.javarosa.engine.xml.ElementParser#parse()
+	 */
 	@Override
 	public Mockup parse() throws InvalidStructureException, IOException, XmlPullParserException {
 		this.checkNode("mockup");

--- a/util/schema-gen/src/org/javarosa/engine/xml/SessionParser.java
+++ b/util/schema-gen/src/org/javarosa/engine/xml/SessionParser.java
@@ -19,6 +19,10 @@ public class SessionParser extends ElementParser<Session> {
 		super(parser);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.javarosa.engine.xml.ElementParser#parse()
+	 */
 	@Override
 	public Session parse() throws InvalidStructureException, IOException, XmlPullParserException {
 		this.checkNode("session");


### PR DESCRIPTION
Documentation-only.

I like having the references to the overridden method around, saves looking up which interface/superclass to go to for documentation.
