### PR TITLE
Fix for 1.3 Java Compatible build

### DIFF
--- a/core/src/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/core/src/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -179,13 +179,17 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
         t.readExternal(new DataInputStream(new ByteArrayInputStream(readBytes(id))), PrototypeManager.getDefault());
         return t;
         } catch (InstantiationException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
         } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
         } catch (DeserializationException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage());
         }
     }
 


### PR DESCRIPTION
FogBugz ticket #143492. 1.3 runtime exceptions can't take exception arguments to the constructor
