### PR TITLE
Fix for min/max not working with paths and argument lists

### DIFF
--- a/core/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReference.java
@@ -597,6 +597,10 @@ public class TreeReference implements Externalizable {
     /**
      * Returns the subreference of this reference up to the level specified.
      * 
+     * For instance, for the reference:
+     * 
+     *   (/data/path/to/node).getSubreference(2) => /data/path/to
+     * 
      * Used to identify the reference context for a predicate at the same level
      * 
      * Must be an absolute reference, otherwise will throw IllegalArgumentException

--- a/core/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -206,19 +206,19 @@ public class XPathFuncExpr extends XPathExpression {
             }  else if (name.equals("count") && args.length == 1) {
                 return count(argVals[0]);
             } else if (name.equals("sum") && args.length == 1) {
-                if (argVals[0] instanceof XPathNodeset) {
+                if (argVals.length == 1 && argVals[0] instanceof XPathNodeset) {
                     return sum(((XPathNodeset)argVals[0]).toArgList());
                 } else {
                     throw new XPathTypeMismatchException("not a nodeset");                
                 }
             } else if (name.equals("max")) {
-                if (argVals[0] instanceof XPathNodeset) {
+                if (argVals.length == 1 && argVals[0] instanceof XPathNodeset) {
                     return max(((XPathNodeset)argVals[0]).toArgList());
                 } else {
                     return max(argVals);                
                 }
             }  else if (name.equals("min")) {
-                if (argVals[0] instanceof XPathNodeset) {
+                if (argVals.length == 1 && argVals[0] instanceof XPathNodeset) {
                     return min(((XPathNodeset)argVals[0]).toArgList());
                 } else {
                     return min(argVals);                

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -119,7 +119,7 @@ public class TreeReferenceTest extends TestCase {
         return aSuite;
     }
     
-    public final static int NUM_TESTS = 7;
+    public final static int NUM_TESTS = 8;
     public void doTest (int i) {
         switch (i) {
         case 1: testClones(); break;
@@ -129,9 +129,15 @@ public class TreeReferenceTest extends TestCase {
         case 5: contextualization(); break;
         case 6: testPredicates(); break;
         case 7: testGenericize(); break;
+        case 8: testSubreferences(); break;
         }
     }
 
+
+    private void testSubreferences() {
+        if(!a.equals(acd.getSubReference(0))) { fail("(/a/c/d).subreference(0) should be: /a"); }
+        if(!ac.equals(acd.getSubReference(1))) { fail("(/a/b/c).subreference(1) should be: /a/c"); }
+    }
 
     public void testSerialization () {
         //TODO: That ^

--- a/core/test/org/javarosa/xpath/test/XPathEvalTest.java
+++ b/core/test/org/javarosa/xpath/test/XPathEvalTest.java
@@ -560,14 +560,14 @@ public class XPathEvalTest extends TestCase {
     }
     
     private void addDataRef (FormInstance dm, String ref, IAnswerData data) {
-        addNodeRef(dm, ref, true);
+        addNodeRef(dm, ref);
         
         if (data != null) {
             dm.resolveReference(new XPathReference(ref)).setValue(data);
         }
     }
     
-    private void addNodeRef (FormInstance dm, String ref, boolean terminal) {
+    private void addNodeRef (FormInstance dm, String ref) {
         TreeReference treeRef = XPathReference.getPathExpr(ref).getReference();
         
         TreeElement lastValidStep = dm.getRoot();

--- a/j2me/buildfiles/build.xml
+++ b/j2me/buildfiles/build.xml
@@ -123,9 +123,6 @@
 		    <fileset dir="${dir.resources-shared}/resources/"/>
    		</copy>
 		
-		<exec executable="hg" outputproperty="jr-build-version">
-			<arg line="parents --template {node|short}"/>
-		</exec>		
 		<echo message="jr-build-version=${jr-build-version}" file="build/javarosa.properties" />
 		
 		<!-- Schweet, now turn it into a 'jar' file! -->
@@ -153,7 +150,7 @@
 
 			<include name="**/test**/*.java"/>
 			
-			<exclude name="crypto/src/**/test/*.java"/>
+			<exclude name="crypto/**/*.java"/>
 		</javac>
 	</target>
 


### PR DESCRIPTION
Removed HG requirement from build process.

Removed crypto tests, since code is no longer included in builds

Updated XPath Eval code to include potential for path driven tests again

Added subreference tests to treereference class tests

added tests for nodeset v. arg list polymorphism

updated treereference docs

Fixed bug with min/max/sum functions taking in argument lists that are paths