### PR TITLE
Output dep cycle parse error

### DIFF
--- a/core/src/org/javarosa/core/services/locale/Localizer.java
+++ b/core/src/org/javarosa/core/services/locale/Localizer.java
@@ -619,48 +619,68 @@ public class Localizer implements Externalizable {
         }
         return args;
     }
-    
+
+    /**
+     * Replace all arguments in 'text', of form ${x}, with the value 'x' maps
+     * to in 'args'.
+     *
+     * @param text String that potentially contains arguments to be evaluated
+     * in the 'args' context.
+     * @param args Hashtable from string keys to values that can be cast to
+     * String.
+     * @return String with all arguments from 'text' present in 'args' context
+     * replaced with their values.
+     */
     public static String processArguments(String text, Hashtable args) {
         int i = text.indexOf("${");
+
+        // find every instance of ${some_key} in text and replace it with the
+        // value that some_key maps to in args.
         while (i != -1) {
             int j = text.indexOf("}", i);
+
+            // abort if no closing bracket
             if (j == -1) {
                 System.err.println("Warning: unterminated ${...} arg");
                 break;
             }
 
             String argName = text.substring(i + 2, j);
-            String argVal = (String)args.get(argName);
+            String argVal = (String) args.get(argName);
+            // if we found a mapping in the args table, perform text substitution
             if (argVal != null) {
                 text = text.substring(0, i) + argVal + text.substring(j + 1);
                 j = i + argVal.length() - 1;
             }
-            
+
             i = text.indexOf("${", j + 1);
         }
         return text;
     }
-    
+
     public static String processArguments(String text, String[] args) {
-        return processArguments(text, args, 0); 
+        return processArguments(text, args, 0);
     }
-    
+
     public static String processArguments(String text, String[] args, int currentArg) {
         String working = text;
-        if(working.indexOf("${") != -1 && args.length > currentArg) {
+
+        if (working.indexOf("${") != -1 && args.length > currentArg) {
             int index = extractNextIndex(working, args);
+
             if(index == -1) {
                 index = currentArg;
                 currentArg++;
             }
+
             String value = args[index];
             String[] replaced = replaceFirstValue(working, value);
-            return replaced[0] + processArguments(replaced[1], args, currentArg); 
+            return replaced[0] + processArguments(replaced[1], args, currentArg);
         } else {
             return working;
         }
     }
-    
+
 
     public static String clearArguments(String text) {
         Vector v = getArgs(text);

--- a/core/src/org/javarosa/xform/util/XFormUtils.java
+++ b/core/src/org/javarosa/xform/util/XFormUtils.java
@@ -114,56 +114,82 @@ public class XFormUtils {
         }
         return returnForm;
     }
-    
-    
-    /////Parser Attribute warning stuff
-    
-    public static Vector getAttributeList(Element e){
+
+
+    // -------------------------------------------------
+    // Attribute parsing validation functions
+    // -------------------------------------------------
+
+    /**
+     * Get the list of attributes in an element
+     * @param e Element that potentially has attributes in it
+     * @return Vector (of String) attributes inside of element
+     */
+    public static Vector getAttributeList(Element e) {
         Vector atts = new Vector();
-        for(int i=0;i<e.getAttributeCount();i++){
+
+        for(int i=0; i < e.getAttributeCount(); i++){
             atts.addElement(e.getAttributeName(i));
         }
-        
+
         return atts;
     }
-    
-    public static Vector getUnusedAttributes(Element e,Vector usedAtts){
+
+    /**
+     * @param e an Element with attributes
+     * @param usedAtts Vector (of String) attributes
+     * @return Vector (of String) attributes from 'e' that aren't in 'usedAtts'
+     */
+    public static Vector getUnusedAttributes(Element e, Vector usedAtts) {
         Vector unusedAtts = getAttributeList(e);
-        for(int i=0;i<usedAtts.size();i++){
-            if(unusedAtts.contains(usedAtts.elementAt(i))){
+        for(int i=0; i < usedAtts.size(); i++){
+            if (unusedAtts.contains(usedAtts.elementAt(i))) {
                 unusedAtts.removeElement(usedAtts.elementAt(i));
             }
         }
-        
+
         return unusedAtts;
     }
-    
-    public static String unusedAttWarning(Element e, Vector usedAtts){
+
+    /**
+     * @param e an Element with attributes
+     * @param usedAtts Vector (of String) attributes
+     * @return String warning about which attributes from 'e' aren't in 'usedAtts'
+     */
+    public static String unusedAttWarning(Element e, Vector usedAtts) {
         String warning = "";
-        Vector ua = getUnusedAttributes(e,usedAtts);
-        warning+=ua.size()+" Unrecognized attributes found in Element ["+e.getName()+"] and will be ignored: ";
-        warning+="[";
-        for(int i=0;i<ua.size();i++){
-            warning+=ua.elementAt(i);
-            if(i!=ua.size()-1) warning+=",";
+        Vector unusedAtts = getUnusedAttributes(e, usedAtts);
+
+        warning += unusedAtts.size() + " unrecognized attributes found in Element [" +
+                   e.getName() + "] and will be ignored: ";
+        warning += "[";
+        for(int i=0; i < unusedAtts.size(); i++){
+            warning += unusedAtts.elementAt(i);
+            if (i != unusedAtts.size() - 1) {
+              warning += ",";
+            }
         }
-        warning+="] ";
-        
+        warning += "] ";
+
         return warning;
     }
-    
+
+    /**
+     * @param e an Element with attributes
+     * @param usedAtts Vector (of String) attributes
+     * @return boolean representing whether there are any attributes in 'e' not
+     * in 'usedAtts'
+     */
     public static boolean showUnusedAttributeWarning(Element e, Vector usedAtts){
-        return getUnusedAttributes(e,usedAtts).size()>0;
+        return getUnusedAttributes(e, usedAtts).size() > 0;
     }
-    
+
     /**
      * Is this element an Output tag?
-     * @param e
-     * @return
+     * @param e Element
+     * @return boolean
      */
-    public static boolean isOutput(Element e){
-        if(e.getName().toLowerCase().equals("output")) return true;
-        else return false;
+    public static boolean isOutput(Element e) {
+        return e.getName().toLowerCase().equals("output");
     }
-    
 }


### PR DESCRIPTION
Fixing bug where when <output> structures in labels are malformed (example below), the xpath parser throws a message which bubbles up but makes no sense to the end user,

"Dependency cycle in <output>s; recursion limit exceeded!!"

This message should instead simply specify something like:

"Malformed expression: TEXT_OF_EXPRESSION_HERE"

Example:
<output ref="instance('casedb')/casedb/case[@case_id=current()/../../@id)]/case_name"/>