### PR TITLE
Fix for Predicate Optimization Evaluation Bug

### DIFF
--- a/core/src/org/javarosa/core/model/instance/utils/TreeUtilities.java
+++ b/core/src/org/javarosa/core/model/instance/utils/TreeUtilities.java
@@ -158,7 +158,14 @@ public class TreeUtilities {
                             String attributeName = attributes.elementAt(j);
  
                             for(int kidI = 0 ; kidI < kids.size() ; ++kidI) {
-                                if(kids.elementAt(kidI).getAttributeValue(null, attributeName).equals(literalMatch)) {
+                                String attrValue = kids.elementAt(kidI).getAttributeValue(null, attributeName);
+                                
+                                //We don't necessarily having typing information for these attributes (and if we did
+                                //it's not available here) so we will try to do some _very basic_ type inference
+                                //on this value before performing the match
+                                Object value = XPathFuncExpr.InferType(attrValue);
+                                
+                                if(XPathEqExpr.testEquality(value, literalMatch)) {
                                     predicateMatches.addElement(kids.elementAt(kidI).getRef());
                                 }
                             }

--- a/core/src/org/javarosa/xpath/expr/XPathEqExpr.java
+++ b/core/src/org/javarosa/xpath/expr/XPathEqExpr.java
@@ -39,6 +39,43 @@ public class XPathEqExpr extends XPathBinaryOpExpr {
     public Object eval (DataInstance model, EvaluationContext evalContext) {
         Object aval = XPathFuncExpr.unpack(a.eval(model, evalContext));
         Object bval = XPathFuncExpr.unpack(b.eval(model, evalContext));
+        boolean eq = testEquality(aval, bval);
+        
+        return new Boolean(equal ? eq : !eq);
+    }
+
+    public String toString () {
+        return super.toString(equal ? "==" : "!=");
+    }
+    
+    public boolean equals (Object o) {
+        if (o instanceof XPathEqExpr) {
+            XPathEqExpr x = (XPathEqExpr)o;
+            return super.equals(o) && equal == x.equal;
+        } else {
+            return false;
+        }
+    }
+    
+    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        equal = ExtUtil.readBool(in);
+        super.readExternal(in, pf);
+    }
+
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.writeBool(out, equal);
+        super.writeExternal(out);
+    }
+
+    /**
+     * Test two XPath Objects for equality the same way that they would be tested
+     * if they were the result of an equality operation
+     * 
+     * @param aval XPath Value 
+     * @param bval XPath Value
+     * @return true if the two values are equal, false otherwise
+     */
+    public static boolean testEquality(Object aval, Object bval) {
         boolean eq = false;
 
         if (aval instanceof Boolean || bval instanceof Boolean) {
@@ -66,30 +103,6 @@ public class XPathEqExpr extends XPathBinaryOpExpr {
             bval = XPathFuncExpr.toString(bval);
             eq = (aval.equals(bval));
         }
-        
-        return new Boolean(equal ? eq : !eq);
-    }
-
-    public String toString () {
-        return super.toString(equal ? "==" : "!=");
-    }
-    
-    public boolean equals (Object o) {
-        if (o instanceof XPathEqExpr) {
-            XPathEqExpr x = (XPathEqExpr)o;
-            return super.equals(o) && equal == x.equal;
-        } else {
-            return false;
-        }
-    }
-    
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        equal = ExtUtil.readBool(in);
-        super.readExternal(in, pf);
-    }
-
-    public void writeExternal(DataOutputStream out) throws IOException {
-        ExtUtil.writeBool(out, equal);
-        super.writeExternal(out);
+        return eq;
     }
 }

--- a/core/src/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -1174,4 +1174,24 @@ public class XPathFuncExpr extends XPathExpression {
     }
     
     public static final double DOUBLE_TOLERANCE = 1.0e-12;
+
+    /**
+     * Take in a value (only a string for now, TODO: Extend?) that doesn't
+     * have any type information and attempt to infer a more specific type
+     * that may assist in equality or comparison operations
+     * 
+     * @param attrValue A typeless data object
+     * @return The passed in object in as specific of a type as was able to
+     * be identified.
+     */
+    public static Object InferType(String attrValue) {
+        try{
+            return Double.parseDouble(attrValue);
+        } catch(NumberFormatException ife) {
+            //Not a double
+        }
+        //TODO: What about dates? That is a _super_ expensive
+        //operation to be testing, though...
+        return attrValue;
+    }
 }


### PR DESCRIPTION
Added a compliment of new tests to ensure predicate matching follows expected semantics to prevent regressions, and fixed an issue resulting in inconsistent predicate matching behaviors when unknown data types weren't being evaluated numerically