### PR TITLE
Adding core tests build

### DIFF
--- a/core/build.properties
+++ b/core/build.properties
@@ -1,0 +1,16 @@
+build=bin
+dist=dist
+src=src
+test-build=test-build
+dir.root=${basedir}/../
+dir.lib=${dir.root}/lib/
+
+# Point the following to wherever you downloaded the javarosa library
+# dependencies to. This dir should contain a j2me dir with ant-contrib.jar and
+# javarosa-ant-libs.jar in it.
+javarosa-dependencies=${basedir}/../javarosa-deps/
+
+ant-contrib=${javarosa-dependencies}/j2me/buildfiles/tools/ant-contrib.jar
+
+name=javarosa-libraries
+jar=${name}.jar

--- a/core/build.xml
+++ b/core/build.xml
@@ -52,7 +52,7 @@
         <delete dir="${build}"/>
     </target>
 
-    <target name="compile" depends="clean, extract-libs, init" description="compile the source">
+    <target name="compile" depends="extract-libs, init" description="compile the source">
         <!-- To get rid of
              "bootstrap class path not set in conjunction with -source 1.5" warning
              add bootclasspath="path/to/java/instance/rt.jar" attribute to javac tag -->

--- a/core/build.xml
+++ b/core/build.xml
@@ -1,14 +1,42 @@
 <?xml version="1.0"?>
 <project default="package">
+    <!-- ///////////////////////////////////////////// -->
+    <!-- Setup                                         -->
+    <!-- ///////////////////////////////////////////// -->
+    <!-- directory locations -->
     <property name="build" location="bin"/>
     <property name="dist" location="dist"/>
     <property name="src" location="src"/>
-
-
-    <property name="name" value="javarosa-libraries"/>
-    <property name="jar" value="${name}.jar"/>
+    <property name="test-build" location="test-build"/>
     <property name="dir.root" value="${basedir}/../"/>
     <property name="dir.lib" value="${dir.root}/lib/"/>
+
+    <!-- Point the following to wherever you downloaded the javarosa library
+         dependencies to. This dir should contain a j2me dir with
+         ant-contrib.jar and javarosa-ant-libs.jar in it. -->
+    <property name="javarosa-dependencies" location="${basedir}/../javarosa-deps/"/>
+
+    <!-- Setup build variables -->
+    <property name="name" value="javarosa-libraries"/>
+    <property name="jar" value="${name}.jar"/>
+
+    <!-- Include ant contrib library to use fancy things like "for" and "if" tasks -->
+    <taskdef resource="net/sf/antcontrib/antlib.xml">
+        <classpath>
+            <pathelement location="${javarosa-dependencies}/j2me/buildfiles/tools/ant-contrib.jar"/>
+        </classpath>
+    </taskdef>
+
+    <!-- Test resource files -->
+    <fileset id="test.resources" dir="${basedir}/../">
+        <include name="**/resources/*.txt"/>
+        <include name="**/resources/*.x*ml/"/>
+    </fileset>
+
+
+    <!-- ///////////////////////////////////////////// -->
+    <!-- Build targets                                 -->
+    <!-- ///////////////////////////////////////////// -->
 
     <target name="init" description="set classpath and make needed directories">
         <mkdir dir="lib/"/>
@@ -24,11 +52,10 @@
         <delete dir="${build}"/>
     </target>
 
-    <target name="compile" depends="clean,extract-libs,init" description="compile the source">
-        <!-- To get rid of "bootstrap class path not set in conjunction with
-             -source 1.5" warning add
-             bootclasspath="path/to/java/instance/rt.jar" attribute to javac
-             tag -->
+    <target name="compile" depends="clean, extract-libs, init" description="compile the source">
+        <!-- To get rid of
+             "bootstrap class path not set in conjunction with -source 1.5" warning
+             add bootclasspath="path/to/java/instance/rt.jar" attribute to javac tag -->
         <javac srcdir="${src}" destdir="${build}"
             classpathref="classpath"
             debug="true" debuglevel="lines,source"
@@ -51,4 +78,103 @@
     <target name="extract-libs" if="extract-libs-fresh">
         <unzip src="${javarosa-deps}" dest="${dir.root}" overwrite="true" />
     </target>
+
+    <target name="packageTestResources" description="pack-up test resource files into jar">
+        <mkdir dir="${test-build}"/>
+        <mkdir dir="${test-build}/tmp"/>
+
+        <copy todir="${test-build}/tmp">
+            <fileset refid="test.resources"/>
+            <flattenmapper/>
+        </copy>
+
+        <zip destfile="${test-build}/jr-test-resource-jar.jar" basedir="${test-build}/tmp"/>
+
+        <delete dir="${test-build}/tmp"/>
+
+        <!-- Setup the test classpath now that everything has been created in it -->
+        <path id="test.classpath">
+            <fileset dir="${test-build}" includes="jr-test-resource-jar.jar"/>
+            <fileset dir="${dir.lib}" includes="*.jar"/>
+            <fileset dir="${dist}" includes="*.jar"/>
+            <dirset dir="${test-build}" >
+                <exclude name="**/*$*.class"/>
+            </dirset>
+        </path>
+    </target>
+
+    <target name="compileTests" depends="package, packageTestResources" description="compile unit tests">
+        <javac destdir="${test-build}" classpathref="test.classpath" includeantruntime="false">
+            <src path="${basedir}"/>
+            <include name="**/test**/*.java"/>
+            <exclude name="crypto/**/*.java"/>
+        </javac>
+    </target>
+
+    <target name="test" depends="compileTests" description="Runs all unit tests found in the code">
+        <fileset id="dist.contents.test" dir="${test-build}" includes="**/*.class" excludes="**/*$*.class"/>
+
+        <!-- Now, convert that source list into a property which is newline seperated, and contains references
+                that start assuming you're in a zip file and in the src directory already -->
+        <pathconvert pathsep="${line.separator}" property="testclasses" refid="dist.contents.test">
+            <chainedmapper>
+                <!-- Cut all non-local elements from the path -->
+                <regexpmapper from="^(.*)${test-build}(.*)$$" to="\2"/>
+                <!-- Now covert from seperators to package seperators -->
+                <filtermapper>
+                    <replacestring from="\" to="."/>
+                    <replacestring from="/" to="."/>
+                </filtermapper>
+                <!-- Trim leading seperators -->
+                <globmapper from=".*" to="*"/>
+                <!-- snip the .class, we should now be left with fully qualified classnames -->
+                <globmapper from="*.class" to="*"/>
+            </chainedmapper>
+        </pathconvert>
+
+        <typedef name="instanceof" classname="org.javarosa.build.InstanceOfCondition" onerror="report">
+            <classpath>
+                <pathelement location="${javarosa-dependencies}/j2me/buildfiles/tools/javarosa-ant-libs.jar"/>
+                <path refid="test.classpath" />
+            </classpath>
+        </typedef>
+
+        <!-- Run tests that extend TestCase -->
+        <for list="${testclasses}" delimiter="${line.separator}" param="testclassname">
+            <sequential>
+                <if>
+                    <instanceof classname="@{testclassname}" baseclass="j2meunit.framework.TestCase"/>
+                    <then>
+                        <echo message="@{testclassname}" />
+                        <RunTestSuite suite="@{testclassname}"/>
+                    </then>
+                </if>
+            </sequential>
+        </for>
+        <fail if="testresult.global">Unit Tests Failed!</fail>
+    </target>
+
+    <!-- ///////////////////////////////////////////// -->
+    <!-- Macros                                        -->
+    <!-- ///////////////////////////////////////////// -->
+
+    <!-- Runs a test suite, and sets testresult.global to be true on failure -->
+    <macrodef name="RunTestSuite" description="Runs a test suite, and sets testresult.global to be true on failure">
+        <attribute name="suite"/>
+        <!-- Note: The reason that we are using @{suite} as a property is because properties in ANT
+            are immutable, and this is a unique identifier -->
+        <sequential>
+            <java classname="j2meunit.textui.TestRunner" failonerror="false" fork="true" resultproperty="@{suite}">
+                <classpath refid="test.classpath" />
+                <arg value="@{suite}"/>
+            </java>
+            <condition property="testresult.global">
+                <not>
+                    <equals arg1="${@{suite}}" arg2="0"/>
+                </not>
+            </condition>
+        </sequential>
+    </macrodef>
+
+
 </project>

--- a/core/build.xml
+++ b/core/build.xml
@@ -1,29 +1,12 @@
 <?xml version="1.0"?>
 <project default="package">
-    <!-- ///////////////////////////////////////////// -->
-    <!-- Setup                                         -->
-    <!-- ///////////////////////////////////////////// -->
-    <!-- directory locations -->
-    <property name="build" location="bin"/>
-    <property name="dist" location="dist"/>
-    <property name="src" location="src"/>
-    <property name="test-build" location="test-build"/>
-    <property name="dir.root" value="${basedir}/../"/>
-    <property name="dir.lib" value="${dir.root}/lib/"/>
 
-    <!-- Point the following to wherever you downloaded the javarosa library
-         dependencies to. This dir should contain a j2me dir with
-         ant-contrib.jar and javarosa-ant-libs.jar in it. -->
-    <property name="javarosa-dependencies" location="${basedir}/../javarosa-deps/"/>
-
-    <!-- Setup build variables -->
-    <property name="name" value="javarosa-libraries"/>
-    <property name="jar" value="${name}.jar"/>
+    <property file="build.properties"/>
 
     <!-- Include ant contrib library to use fancy things like "for" and "if" tasks -->
     <taskdef resource="net/sf/antcontrib/antlib.xml">
         <classpath>
-            <pathelement location="${javarosa-dependencies}/j2me/buildfiles/tools/ant-contrib.jar"/>
+          <pathelement location="${ant-contrib}"/>
         </classpath>
     </taskdef>
 
@@ -39,7 +22,6 @@
     <!-- ///////////////////////////////////////////// -->
 
     <target name="init" description="set classpath and make needed directories">
-        <mkdir dir="lib/"/>
         <path id="classpath">
             <fileset dir="${dir.lib}" includes="*.jar"/>
         </path>

--- a/core/build.xml
+++ b/core/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <project default="package">
 
+    <property file="local.properties"/>
     <property file="build.properties"/>
 
     <!-- Include ant contrib library to use fancy things like "for" and "if" tasks -->

--- a/core/build.xml
+++ b/core/build.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0"?>
 <project default="package">
-	<property name="name" value="javarosa-libraries"/>
-	<property name="jar" value="${name}.jar"/>
-	<property name="dir.root" value="${basedir}/../"/>
-	<property name="dir.lib" value="${dir.root}/lib/"/>
-	
-	<target name="init" description="set classpath and make needed directories">
-		<mkdir dir="lib/"/>
-		<path id="classpath">
-			<fileset dir="${dir.lib}" includes="*.jar"/>
-		</path>
-		<mkdir dir="bin/"/>
-		<mkdir dir="dist/"/>
-	</target>
-	
-	<target name="clean" description="delete dist and bin directories">
-		<delete dir="dist/"/>
-		<delete dir="bin/"/>
-	</target>
-	
-	<target name="compile" depends="clean,extract-libs,init" description="compile the source">
-		<javac srcdir="src/" destdir="bin/" classpathref="classpath" debug="true" debuglevel="lines,source" source="1.5" target="1.5"/>
-	</target>
-	
-	<target name="package" depends="compile" description="package binary into jar">
-		<jar destfile="dist/${jar}">
-			<fileset dir="bin/" includes="**/*.class"/>
-		</jar>
-	</target>
+    <property name="name" value="javarosa-libraries"/>
+    <property name="jar" value="${name}.jar"/>
+    <property name="dir.root" value="${basedir}/../"/>
+    <property name="dir.lib" value="${dir.root}/lib/"/>
 
-	<!-- for use primarily by the build server to extract the required 3rd-party libraries into the
-	     javarosa source tree. to use this in your own build, set the 'extract-libs-fresh' property,
-	     then also set the 'javarosa-deps' property to the path of the library archive (make sure you
-	     are using the version of the archive compatible with the version you wish to build) -->
-	<target name="extract-libs" if="extract-libs-fresh">
-		<unzip src="${javarosa-deps}" dest="${dir.root}" overwrite="true" />
-	</target>
-	
+    <target name="init" description="set classpath and make needed directories">
+        <mkdir dir="lib/"/>
+        <path id="classpath">
+            <fileset dir="${dir.lib}" includes="*.jar"/>
+        </path>
+        <mkdir dir="bin/"/>
+        <mkdir dir="dist/"/>
+    </target>
+
+    <target name="clean" description="delete dist and bin directories">
+        <delete dir="dist/"/>
+        <delete dir="bin/"/>
+    </target>
+
+    <target name="compile" depends="clean,extract-libs,init" description="compile the source">
+        <javac srcdir="src/" destdir="bin/" classpathref="classpath" debug="true" debuglevel="lines,source" source="1.5" target="1.5"/>
+    </target>
+
+    <target name="package" depends="compile" description="package binary into jar">
+        <jar destfile="dist/${jar}">
+            <fileset dir="bin/" includes="**/*.class"/>
+        </jar>
+    </target>
+
+    <!-- for use primarily by the build server to extract the required 3rd-party libraries into the
+         javarosa source tree. to use this in your own build, set the 'extract-libs-fresh' property,
+         then also set the 'javarosa-deps' property to the path of the library archive (make sure you
+         are using the version of the archive compatible with the version you wish to build) -->
+    <target name="extract-libs" if="extract-libs-fresh">
+        <unzip src="${javarosa-deps}" dest="${dir.root}" overwrite="true" />
+    </target>
+
 </project>

--- a/core/build.xml
+++ b/core/build.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 <project default="package">
+    <property name="build" location="bin"/>
+    <property name="dist" location="dist"/>
+    <property name="src" location="src"/>
+
+
     <property name="name" value="javarosa-libraries"/>
     <property name="jar" value="${name}.jar"/>
     <property name="dir.root" value="${basedir}/../"/>
@@ -10,22 +15,32 @@
         <path id="classpath">
             <fileset dir="${dir.lib}" includes="*.jar"/>
         </path>
-        <mkdir dir="bin/"/>
-        <mkdir dir="dist/"/>
+        <mkdir dir="${dist}"/>
+        <mkdir dir="${build}"/>
     </target>
 
-    <target name="clean" description="delete dist and bin directories">
-        <delete dir="dist/"/>
-        <delete dir="bin/"/>
+    <target name="clean" description="delete dist and build directories">
+        <delete dir="${dist}"/>
+        <delete dir="${build}"/>
     </target>
 
     <target name="compile" depends="clean,extract-libs,init" description="compile the source">
-        <javac srcdir="src/" destdir="bin/" classpathref="classpath" debug="true" debuglevel="lines,source" source="1.5" target="1.5"/>
+        <!-- To get rid of "bootstrap class path not set in conjunction with
+             -source 1.5" warning add
+             bootclasspath="path/to/java/instance/rt.jar" attribute to javac
+             tag -->
+        <javac srcdir="${src}" destdir="${build}"
+            classpathref="classpath"
+            debug="true" debuglevel="lines,source"
+            source="1.5" target="1.5" includeantruntime="false">
+            <!-- Do we want to see lint warnings? -->
+            <!-- <compilerarg value="-Xlint:unchecked"/> -->
+        </javac>
     </target>
 
     <target name="package" depends="compile" description="package binary into jar">
-        <jar destfile="dist/${jar}">
-            <fileset dir="bin/" includes="**/*.class"/>
+        <jar destfile="${dist}/${jar}">
+            <fileset dir="${build}" includes="**/*.class"/>
         </jar>
     </target>
 
@@ -36,5 +51,4 @@
     <target name="extract-libs" if="extract-libs-fresh">
         <unzip src="${javarosa-deps}" dest="${dir.root}" overwrite="true" />
     </target>
-
 </project>

--- a/j2me/buildfiles/build.xml
+++ b/j2me/buildfiles/build.xml
@@ -1,287 +1,287 @@
 <?xml version="1.0"?>
 <project name="J2ME Rosa Library Build" default="package">
-	<tstamp/>
+  <tstamp/>
 
-	<property file="local.properties"/>
-	<property file="build.properties"/>
+  <property file="local.properties"/>
+  <property file="build.properties"/>
 
-	<fileset id="jr.sources" dir="../../">
-		<include name="core/src/**/*.java"/>
-		<include name="j2me/**/src/**/*.java"/>
+  <fileset id="jr.sources" dir="../../">
+    <include name="core/src/**/*.java"/>
+    <include name="j2me/**/src/**/*.java"/>
 
-		<!-- exclude this until we've worked out issues with bluetooth apis -->
-		<exclude name="j2me/communication/src/org/javarosa/communication/bluetooth/**/*.java"/>
-		<exclude name="j2me/communication/src/org/javarosa/communication/sim/**/*.java"/>
-		<!-- exclude this until we've worked out issues with barcode apis -->
-		<exclude name="j2me/media/src/org/javarosa/barcode/**/*.java"/>
-		<exclude name="j2me/media/src/org/javarosa/view/**/Barcode*.java"/>
-		
-		<!-- don't want to put this in the jar for phones that don't suport location -->
-		<!-- We'll actually handle that with polish processors rather than manual exclusion -->
-		<!--exclude name="j2me/location/src/org/javarosa/location/**/*.java"/-->
-		
-		<!-- exclude the demo app code -->
-		<exclude name="j2me/javarosa-app/src/**/*.java"/>
+    <!-- exclude this until we've worked out issues with bluetooth apis -->
+    <exclude name="j2me/communication/src/org/javarosa/communication/bluetooth/**/*.java"/>
+    <exclude name="j2me/communication/src/org/javarosa/communication/sim/**/*.java"/>
+    <!-- exclude this until we've worked out issues with barcode apis -->
+    <exclude name="j2me/media/src/org/javarosa/barcode/**/*.java"/>
+    <exclude name="j2me/media/src/org/javarosa/view/**/Barcode*.java"/>
 
-		<!-- stuff that hasn't been updated to build on the new framework -->
-		<exclude name="j2me/deprecated/org.javarosa.reminders/**/*.java"/>
-		<exclude name="j2me/communication/src/org/javarosa/communication/sms/trigger/**/*.java"/>
+    <!-- don't want to put this in the jar for phones that don't suport location -->
+    <!-- We'll actually handle that with polish processors rather than manual exclusion -->
+    <!--exclude name="j2me/location/src/org/javarosa/location/**/*.java"/-->
 
-		
-		<!-- Exclude all BouncyCastle sources -->
-		<exclude name="j2me/crypto/**"/>
-	</fileset>
+    <!-- exclude the demo app code -->
+    <exclude name="j2me/javarosa-app/src/**/*.java"/>
 
-	<target name="package" depends="clean,init-libs,fetchPolishClassList">
-		<!-- first set source compliance. Java5 is correct, since we're postprocessing -->
-		<property name="ant.build.javac.compiler" value="1.5"/>
-		<property name="ant.build.javac.source" value="1.5"/>
-		<property name="ant.build.javac.target" value="1.5"/>
-		
-		<path id="jr.classpath">
-			<fileset dir="${dir.lib}">
-				<include name="*.jar"/>
-			</fileset>
-			<fileset dir="${wtk.home}/lib" includes="${wtk.includes}"/>
-			<fileset dir="${polish.home}/import" includes="${polish.includes}"/>
-		</path>
+    <!-- stuff that hasn't been updated to build on the new framework -->
+    <exclude name="j2me/deprecated/org.javarosa.reminders/**/*.java"/>
+    <exclude name="j2me/communication/src/org/javarosa/communication/sms/trigger/**/*.java"/>
 
-		<path id="jr.compiled.classpath">
-			<path refid="jr.classpath"/>
-			<fileset dir="dist" includes="j2merosa-libraries.jar"/>
-		</path>
-		
-		<path id="jr.classpath.test">
-			<path refid="jr.compiled.classpath" />
-			<fileset dir="buildTest" includes="jr-resource-jar.jar"/>
-			<fileset dir="${dir.lib}" includes="j2meunit-javarosa.jar"/>
-			<dirset dir="${basedir}">
-				<include name="buildTest/**"/>
-			</dirset>
-		</path>
-		
-		<!-- Get the resource files which'll be used -->
-		<fileset id="jr.resources" dir="${basedir}/../">
-			<include name="**/resources/*.txt"/>
-			<include name="**/resources/*.x*ml/"/>
-		</fileset>
-		
-		<mkdir dir="dist"/>
-		<mkdir dir="build"/>
-		<mkdir dir="build/src"/>
 
-		<!-- collect all relevant sources and put them into one big source chunk -->
-		<copy todir="build">
-			<fileset refid="jr.sources"/>
-			<regexpmapper from="^(.*)src(.*)$$" to="src\2"/>
-		</copy>
+    <!-- Exclude all BouncyCastle sources -->
+    <exclude name="j2me/crypto/**"/>
+  </fileset>
 
-		<!-- Now it's time to make the big file that lets Polish index the source code. This part's tricky,
-		so pay attention.
-		
-		First, create a fileset containing all of the source we've collected -->
-		<fileset id="dist.contents" dir="build/src/" includes="**/*.java"/>
+  <target name="package" depends="clean,init-libs,fetchPolishClassList">
+    <!-- first set source compliance. Java5 is correct, since we're postprocessing -->
+    <property name="ant.build.javac.compiler" value="1.5"/>
+    <property name="ant.build.javac.source" value="1.5"/>
+    <property name="ant.build.javac.target" value="1.5"/>
 
-		<!-- Now, convert that source list into a property which is newline seperated, and contains references
-		that start assuming you're in a zip file and in the src directory already -->
-		<pathconvert pathsep="${line.separator}" property="buildcontents" refid="dist.contents">
-			<chainedmapper>
-				<!-- first, make sure we're using zip file file seperators -->
-				<filtermapper>
-					<replacestring from="\" to="/"/>
-				</filtermapper>
-				<!-- Now, cut all non-local elements from the path -->
-				<regexpmapper from="^(.*)src(.*)$$" to="\2"/>
-				<!-- Finally, trim leading seperators -->
-				<globmapper from="/*" to="*"/>
-			</chainedmapper>
-		</pathconvert>
+    <path id="jr.classpath">
+      <fileset dir="${dir.lib}">
+        <include name="*.jar"/>
+      </fileset>
+      <fileset dir="${wtk.home}/lib" includes="${wtk.includes}"/>
+      <fileset dir="${polish.home}/import" includes="${polish.includes}"/>
+    </path>
 
-		<!-- This is where our magic polish source map goes -->
-		<mkdir dir="build/build/"/>
+    <path id="jr.compiled.classpath">
+      <path refid="jr.classpath"/>
+      <fileset dir="dist" includes="j2merosa-libraries.jar"/>
+    </path>
 
-		<!-- This echo dumps our filelist path from above into the file j2mepolish.index.text, and creates 
-		the file itself -->
-		<echo file="build/build/j2mepolish.index.txt" append="false">${buildcontents}${line.separator}</echo>
+    <path id="jr.classpath.test">
+      <path refid="jr.compiled.classpath" />
+      <fileset dir="buildTest" includes="jr-resource-jar.jar"/>
+      <fileset dir="${dir.lib}" includes="j2meunit-javarosa.jar"/>
+      <dirset dir="${basedir}">
+        <include name="buildTest/**"/>
+      </dirset>
+    </path>
 
-		<!-- The file also needs to contain the files from polish, so we'll grab them from the resources
-		directory. In the future this should be set up even more thoroughly to pull the file _directly_ from
-		a polish jar file, which should be easy enough -->
-		<concat destfile="build/build/j2mepolish.index.txt" append="true">
-			<filelist dir="resources" files="j2mepolish.index.txt"/>
-		</concat>
+    <!-- Get the resource files which'll be used -->
+    <fileset id="jr.resources" dir="${basedir}/../">
+      <include name="**/resources/*.txt"/>
+      <include name="**/resources/*.x*ml/"/>
+    </fileset>
 
-		<!-- Ok, so now compile all of the source so that when people put this jar on their eclipse path and
-		stuff, they can link to the bytecode. It's not necessary for the polsh build, but important for if
-		one wants to look at this like it's a real jar file (it's not) -->
-		<javac destdir="build" classpathref="jr.classpath">
-			<src path="build/src" />
-			<include name="**/*.java"/>
-		</javac>
+    <mkdir dir="dist"/>
+    <mkdir dir="build"/>
+    <mkdir dir="build/src"/>
 
-		<copy todir="build/resources/">
-		    <fileset dir="${dir.resources-shared}/resources/"/>
-   		</copy>
-		
-		<echo message="jr-build-version=${jr-build-version}" file="build/javarosa.properties" />
-		
-		<!-- Schweet, now turn it into a 'jar' file! -->
-		<zip destfile="dist/j2merosa-libraries.jar" basedir="build"/>
-	</target>
-	
-	<target name="packageTestResources">
-		<mkdir dir="buildTest"/>
-		<mkdir dir="buildTest/tmp"/>
-		<copy todir="buildTest/tmp">
-			<fileset refid="jr.resources"/>
-			<flattenmapper/>
-		</copy>
-		<zip destfile="buildTest/jr-resource-jar.jar" basedir="buildTest/tmp"/>
-		<delete dir="buildTest/tmp"/>
-	</target>
+    <!-- collect all relevant sources and put them into one big source chunk -->
+    <copy todir="build">
+      <fileset refid="jr.sources"/>
+      <regexpmapper from="^(.*)src(.*)$$" to="src\2"/>
+    </copy>
 
-	<target name="buildTests" depends="package, packageTestResources">
-		<!-- Ok, so now compile all of the source so that when people put this jar on their eclipse path and
-				stuff, they can link to the bytecode. It's not necessary for the polsh build, but important for if
-				one wants to look at this like it's a real jar file (it's not) -->
-		<javac destdir="buildTest" classpathref="jr.classpath.test">
-			<src path="../../core"/>
-			<src path="../../j2me"/>
+    <!-- Now it's time to make the big file that lets Polish index the source code. This part's tricky,
+    so pay attention.
 
-			<include name="**/test**/*.java"/>
-			
-			<exclude name="crypto/**/*.java"/>
-		</javac>
-	</target>
+    First, create a fileset containing all of the source we've collected -->
+    <fileset id="dist.contents" dir="build/src/" includes="**/*.java"/>
 
-	<!--target name="RunUnitTests" description="Runs all unit tests found in the code" depends="buildTests"-->
-	<target name="RunUnitTests" description="Runs all unit tests found in the code" depends="buildTests">
-		<fileset id="dist.contents.test" dir="buildTest" includes="**/*.class" excludes="**/*$*.class"/>
+    <!-- Now, convert that source list into a property which is newline seperated, and contains references
+    that start assuming you're in a zip file and in the src directory already -->
+    <pathconvert pathsep="${line.separator}" property="buildcontents" refid="dist.contents">
+      <chainedmapper>
+        <!-- first, make sure we're using zip file file seperators -->
+        <filtermapper>
+          <replacestring from="\" to="/"/>
+        </filtermapper>
+        <!-- Now, cut all non-local elements from the path -->
+        <regexpmapper from="^(.*)src(.*)$$" to="\2"/>
+        <!-- Finally, trim leading seperators -->
+        <globmapper from="/*" to="*"/>
+      </chainedmapper>
+    </pathconvert>
 
-		<!-- Now, convert that source list into a property which is newline seperated, and contains references
-				that start assuming you're in a zip file and in the src directory already -->
-		<pathconvert pathsep="${line.separator}" property="testclasses" refid="dist.contents.test">
-			<chainedmapper>
-				<!-- Cut all non-local elements from the path -->
-				<regexpmapper from="^(.*)buildTest(.*)$$" to="\2"/>
-				<!-- Now covert from seperators to package seperators -->
-				<filtermapper>
-					<replacestring from="\" to="."/>
-					<replacestring from="/" to="."/>
-				</filtermapper>
-				<!-- Trim leading seperators -->
-				<globmapper from=".*" to="*"/>
-				<!-- snip the .class, we should now be left with fully qualified classnames -->
-				<globmapper from="*.class" to="*"/>
-			</chainedmapper>
-		</pathconvert>
+    <!-- This is where our magic polish source map goes -->
+    <mkdir dir="build/build/"/>
 
-		<typedef name="instanceof" classname="org.javarosa.build.InstanceOfCondition" onerror="report">
-			<classpath>
-				<pathelement location="${dir.tools}/javarosa-ant-libs.jar"/>
-				<path refid="jr.classpath.test" />
-			</classpath>
-		</typedef>
+    <!-- This echo dumps our filelist path from above into the file j2mepolish.index.text, and creates
+    the file itself -->
+    <echo file="build/build/j2mepolish.index.txt" append="false">${buildcontents}${line.separator}</echo>
 
-		<for list="${testclasses}" delimiter="${line.separator}" param="name">
-			<sequential>
-				<if>
-					<instanceof classname="@{name}" baseclass="j2meunit.framework.TestCase"/>
-					<then>
-						<RunTestSuite suite="@{name}"/>
-					</then>
-				</if>
-			</sequential>
-		</for>
-		<fail if="testresult.global">Unit Tests Failed!</fail>
-	</target>
+    <!-- The file also needs to contain the files from polish, so we'll grab them from the resources
+    directory. In the future this should be set up even more thoroughly to pull the file _directly_ from
+    a polish jar file, which should be easy enough -->
+    <concat destfile="build/build/j2mepolish.index.txt" append="true">
+      <filelist dir="resources" files="j2mepolish.index.txt"/>
+    </concat>
 
-	<target name="CreateJavadoc" depends="package" description="generates javadoc and also UML Diagram">
-		<mkdir dir="${dir.javadoc}"/>
-		<javadoc useexternalfile="yes" sourcepath="build\src" packagenames="org.javarosa.*" destdir="${dir.javadoc}"
-	        	classpathref="jr.compiled.classpath" private="true">
-			<doclet name="org.umlgraph.doclet.UmlGraphDoc"
-	        		  path="${dir.tools}/UMLGraph.jar">
-				<param name="-attributes" />
-				<param name="-operations" />
-				<param name="-qualify" />
-				<param name="-types" />
-				<param name="-visibility" />
-			</doclet>
-			<link href="http://java.sun.com/javame/reference/apis/jsr030/"/>
-			<link href="http://java.sun.com/javame/reference/apis/jsr118/"/>
-			<link href="http://www.j2mepolish.org/javadoc/j2me/"/>
-		</javadoc>
-		<apply executable="dot" dest="${dir.documentation}" parallel="false">
-			<arg value="-Tpng"/>
-			<arg value="-o"/>
-			<targetfile/>
-			<srcfile/>
-			<fileset dir="${dir.documentation}" includes="*.dot"/>
-			<mapper type="glob" from="*.dot" to="*.png"/>
-		</apply>
-	</target>
+    <!-- Ok, so now compile all of the source so that when people put this jar on their eclipse path and
+    stuff, they can link to the bytecode. It's not necessary for the polsh build, but important for if
+    one wants to look at this like it's a real jar file (it's not) -->
+    <javac destdir="build" classpathref="jr.classpath">
+      <src path="build/src" />
+      <include name="**/*.java"/>
+    </javac>
 
-	<target name="BuildRelease" depends="package,CreateJavadoc,RunUnitTests"/>
+    <copy todir="build/resources/">
+      <fileset dir="${dir.resources-shared}/resources/"/>
+    </copy>
 
-	<!-- Macro: Runs a test suite, and sets testresult.global to be true on failure -->
-	<macrodef name="RunTestSuite" description="Runs a test suite, and sets testresult.global to be true on failure">
-		<attribute name="suite"/>
-		<!-- Note: The reason that we are using @{suite} as a property is because properties in ANT
-			are immutable, and this is a unique identifier -->
-		<sequential>
-			<java classname="j2meunit.textui.TestRunner" failonerror="false" fork="true" resultproperty="@{suite}">
-				<classpath refid="jr.classpath.test" />
-				<arg value="@{suite}"/>
-			</java>
-			<condition property="testresult.global">
-				<not>
-					<equals arg1="${@{suite}}" arg2="0"/>
-				</not>
-			</condition>
-		</sequential>
-	</macrodef>
+    <echo message="jr-build-version=${jr-build-version}" file="build/javarosa.properties" />
 
-	<taskdef resource="net/sf/antcontrib/antcontrib.properties" onerror="report">
-		<classpath>
-			<pathelement location="${dir.tools}/ant-contrib.jar"/>
-		</classpath>
-	</taskdef>
+    <!-- Schweet, now turn it into a 'jar' file! -->
+    <zip destfile="dist/j2merosa-libraries.jar" basedir="build"/>
+  </target>
 
-	<target name="clean">
-		<delete dir="dist"/>
-		<delete dir="build"/>
-		<delete dir="buildTest"/>
-		<delete dir="${dir.tmp}"/>
-	</target>
+  <target name="packageTestResources">
+    <mkdir dir="buildTest"/>
+    <mkdir dir="buildTest/tmp"/>
+    <copy todir="buildTest/tmp">
+      <fileset refid="jr.resources"/>
+      <flattenmapper/>
+    </copy>
+    <zip destfile="buildTest/jr-resource-jar.jar" basedir="buildTest/tmp"/>
+    <delete dir="buildTest/tmp"/>
+  </target>
 
-	<target name="fetchPolishClassList">
-		<trycatch reference="exception_ref" >
-			<try>
-				<mkdir dir="${dir.tmp}"/>
-				<unzip src="${polish.jar.build}" dest="${dir.tmp}">
-				    <patternset>
-				        <include name="**/build/j2mepolish.index.txt"/>
-				    </patternset>
-				</unzip>
-				<copy file="${dir.tmp}/build/j2mepolish.index.txt" todir="resources" overwrite="true"/>
-			</try>
-			<catch>
-				<property name="exception" refid="exception_ref" />
-				<property name="message" value="Error trying to extract polish class list:${line.separator}${exception}" />
-				<echo message="${message}" />
-			</catch>
-			<finally>
-				<delete dir="${dir.tmp}"/>
-			</finally>
-		</trycatch>
-	</target>
-	
-	<target name="init-libs">
-		<ant antfile="${dir.root}/core/build.xml" target="extract-libs" inheritAll="true" inheritRefs="false" />
-		
-		<taskdef name="for" classname="net.sf.antcontrib.logic.For" onerror="report" classpath="${dir.tools}/ant-contrib.jar" />
-		<taskdef name="if" classname="net.sf.antcontrib.logic.IfTask" onerror="report" classpath="${dir.tools}/ant-contrib.jar" />
-		<taskdef name="trycatch" classname="net.sf.antcontrib.logic.TryCatchTask" onerror="report" classpath="${dir.tools}/ant-contrib.jar" />
-	</target>
+  <target name="buildTests" depends="package, packageTestResources">
+    <!-- Ok, so now compile all of the source so that when people put this jar on their eclipse path and
+        stuff, they can link to the bytecode. It's not necessary for the polsh build, but important for if
+        one wants to look at this like it's a real jar file (it's not) -->
+    <javac destdir="buildTest" classpathref="jr.classpath.test">
+      <src path="../../core"/>
+      <src path="../../j2me"/>
+
+      <include name="**/test**/*.java"/>
+
+      <exclude name="crypto/**/*.java"/>
+    </javac>
+  </target>
+
+  <!--target name="RunUnitTests" description="Runs all unit tests found in the code" depends="buildTests"-->
+  <target name="RunUnitTests" description="Runs all unit tests found in the code" depends="buildTests">
+    <fileset id="dist.contents.test" dir="buildTest" includes="**/*.class" excludes="**/*$*.class"/>
+
+    <!-- Now, convert that source list into a property which is newline seperated, and contains references
+        that start assuming you're in a zip file and in the src directory already -->
+    <pathconvert pathsep="${line.separator}" property="testclasses" refid="dist.contents.test">
+      <chainedmapper>
+        <!-- Cut all non-local elements from the path -->
+        <regexpmapper from="^(.*)buildTest(.*)$$" to="\2"/>
+        <!-- Now covert from seperators to package seperators -->
+        <filtermapper>
+          <replacestring from="\" to="."/>
+          <replacestring from="/" to="."/>
+        </filtermapper>
+        <!-- Trim leading seperators -->
+        <globmapper from=".*" to="*"/>
+        <!-- snip the .class, we should now be left with fully qualified classnames -->
+        <globmapper from="*.class" to="*"/>
+      </chainedmapper>
+    </pathconvert>
+
+    <typedef name="instanceof" classname="org.javarosa.build.InstanceOfCondition" onerror="report">
+      <classpath>
+        <pathelement location="${dir.tools}/javarosa-ant-libs.jar"/>
+        <path refid="jr.classpath.test" />
+      </classpath>
+    </typedef>
+
+    <for list="${testclasses}" delimiter="${line.separator}" param="name">
+      <sequential>
+        <if>
+          <instanceof classname="@{name}" baseclass="j2meunit.framework.TestCase"/>
+          <then>
+            <RunTestSuite suite="@{name}"/>
+          </then>
+        </if>
+      </sequential>
+    </for>
+    <fail if="testresult.global">Unit Tests Failed!</fail>
+  </target>
+
+  <target name="CreateJavadoc" depends="package" description="generates javadoc and also UML Diagram">
+    <mkdir dir="${dir.javadoc}"/>
+    <javadoc useexternalfile="yes" sourcepath="build\src" packagenames="org.javarosa.*" destdir="${dir.javadoc}"
+      classpathref="jr.compiled.classpath" private="true">
+      <doclet name="org.umlgraph.doclet.UmlGraphDoc"
+        path="${dir.tools}/UMLGraph.jar">
+        <param name="-attributes" />
+        <param name="-operations" />
+        <param name="-qualify" />
+        <param name="-types" />
+        <param name="-visibility" />
+      </doclet>
+      <link href="http://java.sun.com/javame/reference/apis/jsr030/"/>
+      <link href="http://java.sun.com/javame/reference/apis/jsr118/"/>
+      <link href="http://www.j2mepolish.org/javadoc/j2me/"/>
+    </javadoc>
+    <apply executable="dot" dest="${dir.documentation}" parallel="false">
+      <arg value="-Tpng"/>
+      <arg value="-o"/>
+      <targetfile/>
+      <srcfile/>
+      <fileset dir="${dir.documentation}" includes="*.dot"/>
+      <mapper type="glob" from="*.dot" to="*.png"/>
+    </apply>
+  </target>
+
+  <target name="BuildRelease" depends="package,CreateJavadoc,RunUnitTests"/>
+
+  <!-- Macro: Runs a test suite, and sets testresult.global to be true on failure -->
+  <macrodef name="RunTestSuite" description="Runs a test suite, and sets testresult.global to be true on failure">
+    <attribute name="suite"/>
+    <!-- Note: The reason that we are using @{suite} as a property is because properties in ANT
+      are immutable, and this is a unique identifier -->
+    <sequential>
+      <java classname="j2meunit.textui.TestRunner" failonerror="false" fork="true" resultproperty="@{suite}">
+        <classpath refid="jr.classpath.test" />
+        <arg value="@{suite}"/>
+      </java>
+      <condition property="testresult.global">
+        <not>
+          <equals arg1="${@{suite}}" arg2="0"/>
+        </not>
+      </condition>
+    </sequential>
+  </macrodef>
+
+  <taskdef resource="net/sf/antcontrib/antcontrib.properties" onerror="report">
+    <classpath>
+      <pathelement location="${dir.tools}/ant-contrib.jar"/>
+    </classpath>
+  </taskdef>
+
+  <target name="clean">
+    <delete dir="dist"/>
+    <delete dir="build"/>
+    <delete dir="buildTest"/>
+    <delete dir="${dir.tmp}"/>
+  </target>
+
+  <target name="fetchPolishClassList">
+    <trycatch reference="exception_ref" >
+      <try>
+        <mkdir dir="${dir.tmp}"/>
+        <unzip src="${polish.jar.build}" dest="${dir.tmp}">
+          <patternset>
+            <include name="**/build/j2mepolish.index.txt"/>
+          </patternset>
+        </unzip>
+        <copy file="${dir.tmp}/build/j2mepolish.index.txt" todir="resources" overwrite="true"/>
+      </try>
+      <catch>
+        <property name="exception" refid="exception_ref" />
+        <property name="message" value="Error trying to extract polish class list:${line.separator}${exception}" />
+        <echo message="${message}" />
+      </catch>
+      <finally>
+        <delete dir="${dir.tmp}"/>
+      </finally>
+    </trycatch>
+  </target>
+
+  <target name="init-libs">
+    <ant antfile="${dir.root}/core/build.xml" target="extract-libs" inheritAll="true" inheritRefs="false" />
+
+    <taskdef name="for" classname="net.sf.antcontrib.logic.For" onerror="report" classpath="${dir.tools}/ant-contrib.jar" />
+    <taskdef name="if" classname="net.sf.antcontrib.logic.IfTask" onerror="report" classpath="${dir.tools}/ant-contrib.jar" />
+    <taskdef name="trycatch" classname="net.sf.antcontrib.logic.TryCatchTask" onerror="report" classpath="${dir.tools}/ant-contrib.jar" />
+  </target>
 </project>


### PR DESCRIPTION
Round 2, now without extraneous commits from other branches :)
Unit tests can now be built/run from core build file via 'ant test'

Notes:
 - Commit c748cb9 removes 'clean' as a dep for core project compilation. Will this break any automated builds we have in places like jenkins?
 - The only changes to j2me/buildfiles/build.xml are in commit  418b333 and are purely whitespace and retabbing