### PR TITLE
Nokia Phone Repeat Index Fix

### DIFF
--- a/j2me/form-entry/src/org/javarosa/formmanager/view/singlequestionscreen/screen/SingleQuestionScreen.java
+++ b/j2me/form-entry/src/org/javarosa/formmanager/view/singlequestionscreen/screen/SingleQuestionScreen.java
@@ -115,6 +115,11 @@ public class SingleQuestionScreen extends FramedForm implements ItemCommandListe
     }
     
     public void configureProgressBar(int cur, int total) {
+        //Mar 17, 2015 - OQPS doesn't properly deal with progress bar 
+        //when repeats exist. In the short term, just let it stay full
+        //rather than crashing
+        if (cur >= total) { cur = total;}
+        
         if(progressBar == null) {
             //#style progressbar
             progressBar = new Gauge(null, false, total, cur);


### PR DESCRIPTION
Fix for OQPS not working properly when repeats overflow the number of question templates in the form template.

Doesn't actually fix the progress bar (it'll just look full for the rest of the form)

http://manage.dimagi.com/default.asp?160462