### PR TITLE
Cursory clean-up of TreeReference code

### DIFF
--- a/core/src/org/javarosa/core/model/FormDef.java
+++ b/core/src/org/javarosa/core/model/FormDef.java
@@ -92,26 +92,30 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * A unique external name that is used to identify the form between machines
      */
     private Localizer localizer;
-    public Vector<Triggerable> triggerables; // <Triggerable>; this list is topologically ordered, meaning for any tA and tB in
-    //the list, where tA comes before tB, evaluating tA cannot depend on any result from evaluating tB
-    private boolean triggerablesInOrder; //true if triggerables has been ordered topologically (DON'T DELETE ME EVEN THOUGH I'M UNUSED)
+
+    // This list is topologically ordered, meaning for any tA
+    // and tB in the list, where tA comes before tB, evaluating tA cannot
+    // depend on any result from evaluating tB
+    public Vector<Triggerable> triggerables;
+
+    // true if triggerables has been ordered topologically (DON'T DELETE ME
+    // EVEN THOUGH I'M UNUSED)
+    private boolean triggerablesInOrder; 
 
 
-    private Vector outputFragments; // <IConditionExpr> contents of <output>
-    // tags that serve as parameterized
+    // <IConditionExpr> contents of <output> tags that serve as parameterized
     // arguments to captions
+    private Vector outputFragments; 
 
     public Hashtable<TreeReference, Vector<Triggerable>> triggerIndex;
     private Hashtable<TreeReference, Condition> conditionRepeatTargetIndex;
-    // associates repeatable
-    // nodes with the Condition
-    // that determines their
+    // associates repeatable nodes with the Condition that determines their
     // relevancy
     public EvaluationContext exprEvalContext;
 
     private QuestionPreloader preloader = new QuestionPreloader();
 
-    //XML ID's cannot start with numbers, so this should never conflict
+    // XML ID's cannot start with numbers, so this should never conflict
     private static String DEFAULT_SUBMISSION_PROFILE = "1";
 
     private Hashtable<String, SubmissionProfile> submissionProfiles;
@@ -523,9 +527,13 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             }
         }
 
-        triggerTriggerables(destRef); // trigger conditions that depend on the creation of these new nodes
-        initializeTriggerables(destRef); // initialize conditions for the node (and sub-nodes)
-        //not 100% sure this will work since destRef is ambiguous as the last step, but i think it's supposed to work
+        // trigger conditions that depend on the creation of these new nodes
+        triggerTriggerables(destRef); 
+
+        // initialize conditions for the node (and sub-nodes)
+        initializeTriggerables(destRef); 
+        // not 100% sure this will work since destRef is ambiguous as the last
+        // step, but i think it's supposed to work
     }
 
     /**
@@ -536,12 +544,14 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     public Triggerable addTriggerable(Triggerable t) {
         int existingIx = triggerables.indexOf(t);
         if (existingIx >= 0) {
-            //one node may control access to many nodes; this means many nodes effectively have the same condition
-            //let's identify when conditions are the same, and store and calculate it only once
+            // One node may control access to many nodes; this means many nodes
+            // effectively have the same condition. Let's identify when
+            // conditions are the same, and store and calculate it only once.
 
-            //nov-2-2011: ctsims - We need to merge the context nodes together whenever we do this (finding the highest
-            //common ground between the two), otherwise we can end up failing to trigger when the ignored context
-            //exists and the used one doesn't
+            // nov-2-2011: ctsims - We need to merge the context nodes together
+            // whenever we do this (finding the highest common ground between
+            // the two), otherwise we can end up failing to trigger when the
+            // ignored context exists and the used one doesn't
 
             Triggerable existingTriggerable = (Triggerable)triggerables.elementAt(existingIx);
 
@@ -549,9 +559,10 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
             return existingTriggerable;
 
-            //note, if the contextRef is unnecessarily deep, the condition will be evaluated more times than needed
-            //perhaps detect when 'identical' condition has a shorter contextRef, and use that one instead?
-
+            // NOTE: if the contextRef is unnecessarily deep, the condition
+            // will be evaluated more times than needed. Perhaps detect when
+            // 'identical' condition has a shorter contextRef, and use that one
+            // instead?
         } else {
             triggerables.addElement(t);
             triggerablesInOrder = false;

--- a/core/src/org/javarosa/core/model/FormDef.java
+++ b/core/src/org/javarosa/core/model/FormDef.java
@@ -100,12 +100,12 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     // true if triggerables has been ordered topologically (DON'T DELETE ME
     // EVEN THOUGH I'M UNUSED)
-    private boolean triggerablesInOrder; 
+    private boolean triggerablesInOrder;
 
 
     // <IConditionExpr> contents of <output> tags that serve as parameterized
     // arguments to captions
-    private Vector outputFragments; 
+    private Vector outputFragments;
 
     public Hashtable<TreeReference, Vector<Triggerable>> triggerIndex;
     private Hashtable<TreeReference, Condition> conditionRepeatTargetIndex;
@@ -528,10 +528,10 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         }
 
         // trigger conditions that depend on the creation of these new nodes
-        triggerTriggerables(destRef); 
+        triggerTriggerables(destRef);
 
         // initialize conditions for the node (and sub-nodes)
-        initializeTriggerables(destRef); 
+        initializeTriggerables(destRef);
         // not 100% sure this will work since destRef is ambiguous as the last
         // step, but i think it's supposed to work
     }

--- a/core/src/org/javarosa/core/model/condition/Condition.java
+++ b/core/src/org/javarosa/core/model/condition/Condition.java
@@ -117,17 +117,19 @@ public class Condition extends Triggerable {
         }
     }
 
-    //conditions are equal if they have the same actions, expression, and triggers, but NOT targets or context ref
+    /**
+     * Conditions are equal if they have the same actions, expression, and
+     * triggers, but NOT targets or context ref.
+    */
     public boolean equals(Object o) {
         if (o instanceof Condition) {
             Condition c = (Condition)o;
-            if (this == c)
-                return true;
-
-            return (this.trueAction == c.trueAction && this.falseAction == c.falseAction && super.equals(c));
-        } else {
-            return false;
+            return (this == c ||
+                    (this.trueAction == c.trueAction &&
+                    this.falseAction == c.falseAction &&
+                    super.equals(c)));
         }
+        return false;
     }
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {

--- a/core/src/org/javarosa/core/model/condition/Condition.java
+++ b/core/src/org/javarosa/core/model/condition/Condition.java
@@ -49,12 +49,12 @@ public class Condition extends Triggerable {
     }
 
     public Condition(IConditionExpr expr, int trueAction, int falseAction,
-            TreeReference contextRef) {
+                     TreeReference contextRef) {
         this(expr, trueAction, falseAction, contextRef, new Vector());
     }
 
     public Condition(IConditionExpr expr, int trueAction, int falseAction,
-            TreeReference contextRef, Vector targets) {
+                     TreeReference contextRef, Vector targets) {
         super(expr, contextRef);
         this.trueAction = trueAction;
         this.falseAction = falseAction;
@@ -121,14 +121,14 @@ public class Condition extends Triggerable {
     /**
      * Conditions are equal if they have the same actions, expression, and
      * triggers, but NOT targets or context ref.
-    */
+     */
     public boolean equals(Object o) {
         if (o instanceof Condition) {
             Condition c = (Condition)o;
             return (this == c ||
                     (this.trueAction == c.trueAction &&
-                    this.falseAction == c.falseAction &&
-                    super.equals(c)));
+                            this.falseAction == c.falseAction &&
+                            super.equals(c)));
         }
         return false;
     }

--- a/core/src/org/javarosa/core/model/condition/Condition.java
+++ b/core/src/org/javarosa/core/model/condition/Condition.java
@@ -48,11 +48,13 @@ public class Condition extends Triggerable {
 
     }
 
-    public Condition(IConditionExpr expr, int trueAction, int falseAction, TreeReference contextRef) {
+    public Condition(IConditionExpr expr, int trueAction, int falseAction,
+            TreeReference contextRef) {
         this(expr, trueAction, falseAction, contextRef, new Vector());
     }
 
-    public Condition(IConditionExpr expr, int trueAction, int falseAction, TreeReference contextRef, Vector targets) {
+    public Condition(IConditionExpr expr, int trueAction, int falseAction,
+            TreeReference contextRef, Vector targets) {
         super(expr, contextRef);
         this.trueAction = trueAction;
         this.falseAction = falseAction;
@@ -84,7 +86,6 @@ public class Condition extends Triggerable {
     public boolean isCascadingToChildren() {
         return (trueAction == ACTION_SHOW || trueAction == ACTION_HIDE);
     }
-
 
     private void performAction(TreeElement node, int action) {
         switch (action) {

--- a/core/src/org/javarosa/core/model/condition/Triggerable.java
+++ b/core/src/org/javarosa/core/model/condition/Triggerable.java
@@ -93,7 +93,7 @@ public abstract class Triggerable implements Externalizable {
      * @param f
      */
     public final void apply(FormInstance instance, EvaluationContext parentContext,
-            TreeReference context, FormDef f) {
+                            TreeReference context, FormDef f) {
         // The triggering root is the highest level of actual data we can
         // inquire about, but it _isn't_ necessarily the basis for the actual
         // expressions, so we need genericize that ref against the current
@@ -105,7 +105,7 @@ public abstract class Triggerable implements Externalizable {
 
         for (int i = 0; i < targets.size(); i++) {
             TreeReference targetRef =
-                ((TreeReference)targets.elementAt(i)).contextualize(ec.getContextRef());
+                    ((TreeReference)targets.elementAt(i)).contextualize(ec.getContextRef());
             Vector v = ec.expandReference(targetRef);
 
             for (int j = 0; j < v.size(); j++) {

--- a/core/src/org/javarosa/core/model/condition/Triggerable.java
+++ b/core/src/org/javarosa/core/model/condition/Triggerable.java
@@ -38,7 +38,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory;
  * which represents where the resultant value will be stored.
  *
  * A triggerable will dispatch the action it's performing out to
- * all relevant nodes referenced by the context against thes current
+ * all relevant nodes referenced by the context against these current
  * models.
  *
  * @author ctsims
@@ -56,8 +56,9 @@ public abstract class Triggerable implements Externalizable {
     public Vector<TreeReference> targets;
 
     /**
-     * Current reference which is the "Basis" of the trigerrables being evaluated. This is the highest
-     * common root of all of the targets being evaluated.
+     * Current reference which is the "Basis" of the trigerrables being
+     * evaluated. This is the highest common root of all of the targets being
+     * evaluated.
      */
     public TreeReference contextRef;  //generic ref used to turn triggers into absolute references
 
@@ -87,20 +88,26 @@ public abstract class Triggerable implements Externalizable {
      * Not for re-implementation, dispatches all of the evaluation
      *
      * @param instance
-     * @param evalContext
+     * @param parentContext
+     * @param context
      * @param f
      */
-    public final void apply(FormInstance instance, EvaluationContext parentContext, TreeReference context, FormDef f) {
-        //The triggeringRoot is the highest level of actual data we can inquire about, but it _isn't_ necessarily the basis
-        //for the actual expressions, so we need genericize that ref against the current context
+    public final void apply(FormInstance instance, EvaluationContext parentContext,
+            TreeReference context, FormDef f) {
+        // The triggering root is the highest level of actual data we can
+        // inquire about, but it _isn't_ necessarily the basis for the actual
+        // expressions, so we need genericize that ref against the current
+        // context
         TreeReference ungenericised = originalContextRef.contextualize(context);
         EvaluationContext ec = new EvaluationContext(parentContext, ungenericised);
 
         Object result = eval(instance, ec);
 
         for (int i = 0; i < targets.size(); i++) {
-            TreeReference targetRef = ((TreeReference)targets.elementAt(i)).contextualize(ec.getContextRef());
+            TreeReference targetRef =
+                ((TreeReference)targets.elementAt(i)).contextualize(ec.getContextRef());
             Vector v = ec.expandReference(targetRef);
+
             for (int j = 0; j < v.size(); j++) {
                 TreeReference affectedRef = (TreeReference)v.elementAt(j);
                 apply(affectedRef, result, instance, f);
@@ -131,7 +138,9 @@ public abstract class Triggerable implements Externalizable {
     }
 
     public Vector<TreeReference> getTriggers() {
+        // grab the relative trigger references from expression
         Vector<TreeReference> relTriggers = expr.getTriggers();
+        // construct absolute references by anchoring against the original context reference
         Vector<TreeReference> absTriggers = new Vector<TreeReference>();
         for (int i = 0; i < relTriggers.size(); i++) {
             absTriggers.addElement(((TreeReference)relTriggers.elementAt(i)).anchor(originalContextRef));

--- a/core/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReference.java
@@ -194,12 +194,15 @@ public class TreeReference implements Externalizable {
     }
 
     /**
-     * return true if this ref contains any unbound multiplicities... ie, there
-     * is ANY chance this ref could ambiguously refer to more than one instance
-     * node.
+     * Does this reference reference contains any unbound multiplicities?
+     * Unbounded multiplicities means there is a chance that this reference
+     * could refer to more than one instance node.
+     *
+     * @return Does this reference have the potential to point to more than one
+     * instance node?
      */
     public boolean isAmbiguous() {
-        //ignore level 0, as /data implies /data[0]
+        // ignore level 0, as /data implies /data[0]
         for (int i = 1; i < size(); i++) {
             if (getMultiplicity(i) == INDEX_UNBOUND) {
                 return true;
@@ -388,13 +391,20 @@ public class TreeReference implements Externalizable {
         }
     }
 
-    //turn unambiguous ref into a generic ref
+    /**
+     * Turn an un-ambiguous reference into a generic one. This is acheived by
+     * setting the multiplicity of every reference level to unbounded.
+     *
+     * @return a clone of this reference with every reference level's
+     * multiplicity set to unbounded.
+     */
     public TreeReference genericize() {
         TreeReference genericRef = clone();
         for (int i = 0; i < genericRef.size(); i++) {
-            //TODO: It's not super clear whether template refs should get
-            //genericized or not
-            if (genericRef.getMultiplicity(i) > -1 || genericRef.getMultiplicity(i) == INDEX_TEMPLATE) {
+            // TODO: It's not super clear whether template refs should get
+            // genericized or not
+            if (genericRef.getMultiplicity(i) > -1 ||
+                    genericRef.getMultiplicity(i) == INDEX_TEMPLATE) {
                 genericRef.setMultiplicity(i, INDEX_UNBOUND);
             }
         }
@@ -445,6 +455,14 @@ public class TreeReference implements Externalizable {
         return childRef;
     }
 
+    /**
+     * Equality of two TreeReferences comes down to having the same reference
+     * level, and equal reference levels entries.
+     *
+     * @param o an object to compare against this TreeReference object.
+     * @return Is object o a TreeReference with equal reference level entries
+     * to this object?
+     */
     public boolean equals(Object o) {
         //csims@dimagi.com - Replaced this function performing itself fully written out
         //rather than allowing the tree reference levels to denote equality. The only edge
@@ -456,25 +474,23 @@ public class TreeReference implements Externalizable {
             TreeReference ref = (TreeReference)o;
 
             if (this.refLevel == ref.refLevel && this.size() == ref.size()) {
-
+                // loop through reference segments, comparing their equality
                 for (int i = 0; i < this.size(); i++) {
-                    TreeReferenceLevel l = data.elementAt(i);
-                    TreeReferenceLevel other = ref.data.elementAt(i);
+                    TreeReferenceLevel thisLevel = data.elementAt(i);
+                    TreeReferenceLevel otherLevel = ref.data.elementAt(i);
 
-                    //we should expect this to hit a lot due to interning
-                    if (l.equals(other)) {
+                    // we should expect this to hit a lot due to interning
+                    if (thisLevel.equals(otherLevel)) {
                         continue;
                     } else {
                         return false;
                     }
                 }
                 return true;
-            } else {
-                return false;
             }
-        } else {
-            return false;
-        }
+        } 
+
+        return false;
     }
 
     public int hashCode() {

--- a/core/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReference.java
@@ -499,23 +499,30 @@ public class TreeReference implements Externalizable {
     }
 
     /**
-     * returns true if 'this' is parent of 'child'
-     * return true if 'this' equals 'child' only if properParent is false
+     * Are these reference's levels subsumed by equivalently named 'child'
+     * levels of the same multiplicity?
+     *
+     * @param child check if this reference is a child of the current reference
+     * @param properParent when set don't return true if 'child' is equal to
+     * this
+     * @return true if 'this' is parent of 'child' or if 'this' equals 'child'
+     * (when properParent is false)
      */
     public boolean isParentOf(TreeReference child, boolean properParent) {
-        //Instances and context types;
-        if (refLevel != child.refLevel) {
-            return false;
-        }
-        if (child.size() < size() + (properParent ? 1 : 0)) {
+        if ((refLevel != child.refLevel) ||
+                (child.size() < (size() + (properParent ? 1 : 0)))) {
             return false;
         }
 
         for (int i = 0; i < size(); i++) {
+            // check that levels names are the same
             if (!this.getName(i).equals(child.getName(i))) {
                 return false;
             }
 
+            // check that multiplicities are the same; allowing them to differ
+            // if on 0-th level, parent mult is the default and child is
+            // unbounded.
             int parMult = this.getMultiplicity(i);
             int childMult = child.getMultiplicity(i);
             if (parMult != INDEX_UNBOUND &&

--- a/core/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReference.java
@@ -99,6 +99,7 @@ public class TreeReference implements Externalizable {
 
     /**
      * Build a '/' reference
+     *
      * @return a reference that represents a root/'/' path
      */
     public static TreeReference rootRef() {
@@ -110,6 +111,7 @@ public class TreeReference implements Externalizable {
 
     /**
      * Build a '.' reference
+     *
      * @return a reference that represents a self/'.' path
      */
     public static TreeReference selfRef() {
@@ -346,7 +348,7 @@ public class TreeReference implements Externalizable {
      * Join this reference with the base reference argument.
      *
      * @param baseRef an absolute reference or a relative reference with only
-     * '../'s
+     *                '../'s
      * @return a join of this reference with the base reference argument.
      * Returns a clone of this reference if it is absolute, and null if this
      * reference has '../'s but baseRef argument a non-empty relative reference.
@@ -502,9 +504,9 @@ public class TreeReference implements Externalizable {
      * Are these reference's levels subsumed by equivalently named 'child'
      * levels of the same multiplicity?
      *
-     * @param child check if this reference is a child of the current reference
+     * @param child        check if this reference is a child of the current reference
      * @param properParent when set don't return true if 'child' is equal to
-     * this
+     *                     this
      * @return true if 'this' is parent of 'child' or if 'this' equals 'child'
      * (when properParent is false)
      */

--- a/core/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReference.java
@@ -75,7 +75,8 @@ public class TreeReference implements Externalizable {
 
     public static final String NAME_WILDCARD = "*";
 
-    private int refLevel; //0 = context node, 1 = parent, 2 = grandparent ...
+    // -1 = absolute, 0 = context node, 1 = parent, 2 = grandparent ...
+    private int refLevel;
     private int contextType;
     private String instanceName = null;
     private Vector<TreeReferenceLevel> data = null;
@@ -433,7 +434,6 @@ public class TreeReference implements Externalizable {
     /**
      * clone and extend a reference by one level
      *
-     * @param ref
      * @param name
      * @param mult
      * @return
@@ -649,31 +649,31 @@ public class TreeReference implements Externalizable {
      * Returns the subreference of this reference up to the level specified.
      *
      * For instance, for the reference:
-     *
      * (/data/path/to/node).getSubreference(2) => /data/path/to
      *
      * Used to identify the reference context for a predicate at the same level
      *
-     * Must be an absolute reference, otherwise will throw IllegalArgumentException
-     *
-     * @param i
-     * @return
+     * @param level number of segments to include in the truncated
+     * sub-reference.
+     * @throws IllegalArgumentException if this object isn't an absolute
+     * reference.
+     * @return A clone of this reference object that includes steps up the
+     * specified level.
      */
     public TreeReference getSubReference(int level) {
         if (!this.isAbsolute()) {
             throw new IllegalArgumentException("Cannot subreference a non-absolute ref");
         }
 
-        //Copy construct
-        TreeReference ret = new TreeReference();
-        ret.refLevel = this.refLevel;
-        ret.contextType = this.contextType;
-        ret.instanceName = this.instanceName;
-        ret.data = new Vector<TreeReferenceLevel>();
+        TreeReference subRef = new TreeReference();
+        subRef.refLevel = this.refLevel;
+        subRef.contextType = this.contextType;
+        subRef.instanceName = this.instanceName;
+
         for (int i = 0; i <= level; ++i) {
-            ret.data.addElement(this.data.elementAt(i));
+            subRef.add(this.data.elementAt(i).shallowCopy());
         }
-        return ret;
+        return subRef;
     }
 
     public boolean hasPredicates() {

--- a/core/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -27,7 +27,12 @@ public class TreeReferenceLevel implements Externalizable {
     private int multiplicity = MULT_UNINIT;
     private Vector<XPathExpression> predicates;
 
+    // a cache for refence levels, to avoid keeping a bunch of the same levels
+    // floating around at run-time.
     private static Interner<TreeReferenceLevel> refs;
+
+    // Do we want to keep a cache of all reference levels?
+    public static boolean treeRefLevelInterningEnabled = true;
 
     public static void attachCacheTable(Interner<TreeReferenceLevel> refs) {
         TreeReferenceLevel.refs = refs;
@@ -60,6 +65,14 @@ public class TreeReferenceLevel implements Externalizable {
         return new TreeReferenceLevel(name, mult, predicates).intern();
     }
 
+    /**
+     * Create a copy of this level with updated predicates.
+     *
+     * @param xpe vector of xpath expressions representing predicates to attach
+     * to a copy of this reference level.
+     * @return a (cached-)copy of this reference level with the predicates argument
+     * attached.
+     */
     public TreeReferenceLevel setPredicates(Vector<XPathExpression> xpe) {
         return new TreeReferenceLevel(name, multiplicity, xpe).intern();
     }
@@ -141,8 +154,9 @@ public class TreeReferenceLevel implements Externalizable {
         return true;
     }
 
-    public static boolean treeRefLevelInterningEnabled = true;
-
+    /**
+     * Make sure this object has been added to the cache table.
+     */
     public TreeReferenceLevel intern() {
         if (!treeRefLevelInterningEnabled || refs == null) {
             return this;

--- a/core/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -82,7 +82,8 @@ public class TreeReferenceLevel implements Externalizable {
     }
 
     public TreeReferenceLevel shallowCopy() {
-        return new TreeReferenceLevel(name, multiplicity, ArrayUtilities.vectorCopy(predicates)).intern();
+        return new TreeReferenceLevel(name, multiplicity,
+                ArrayUtilities.vectorCopy(predicates)).intern();
     }
 
 

--- a/core/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -69,7 +69,7 @@ public class TreeReferenceLevel implements Externalizable {
      * Create a copy of this level with updated predicates.
      *
      * @param xpe vector of xpath expressions representing predicates to attach
-     * to a copy of this reference level.
+     *            to a copy of this reference level.
      * @return a (cached-)copy of this reference level with the predicates argument
      * attached.
      */
@@ -119,6 +119,7 @@ public class TreeReferenceLevel implements Externalizable {
     /**
      * Two TreeReferenceLevels are equal if they have the same name,
      * multiplicity, and equal predicates.
+     *
      * @param o an object to compare against this TreeReferenceLevel object.
      * @return Is object o a TreeReferenceLevel and has the same fields?
      */

--- a/core/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -102,30 +102,37 @@ public class TreeReferenceLevel implements Externalizable {
         return name.hashCode() ^ multiplicity ^ predPart;
     }
 
+    /**
+     * Two TreeReferenceLevels are equal if they have the same name,
+     * multiplicity, and equal predicates.
+     * @param o an object to compare against this TreeReferenceLevel object.
+     * @return Is object o a TreeReferenceLevel and has the same fields?
+     */
     public boolean equals(Object o) {
         if (!(o instanceof TreeReferenceLevel)) {
             return false;
         }
+
         TreeReferenceLevel l = (TreeReferenceLevel)o;
-        if (multiplicity != l.multiplicity) {
+        // multiplicity and names match-up
+        if ((multiplicity != l.multiplicity) ||
+                (name == null && l.name != null) ||
+                (!name.equals(l.name))) {
             return false;
         }
-        if (name == null && l.name != null) {
-            return false;
-        }
-        if (!name.equals(l.name)) {
-            return false;
-        }
+
         if (predicates == null && l.predicates == null) {
             return true;
         }
 
-        if ((predicates == null && l.predicates != null) || (l.predicates == null && predicates != null)) {
+        // predicates match-up
+        if ((predicates == null && l.predicates != null) ||
+                (l.predicates == null && predicates != null) ||
+                (predicates.size() != l.predicates.size())) {
             return false;
         }
-        if (predicates.size() != l.predicates.size()) {
-            return false;
-        }
+
+        // predicate elements are equal
         for (int i = 0; i < predicates.size(); ++i) {
             if (!predicates.elementAt(i).equals(l.predicates.elementAt(i))) {
                 return false;

--- a/core/src/org/javarosa/xpath/XPathConditional.java
+++ b/core/src/org/javarosa/xpath/XPathConditional.java
@@ -101,7 +101,8 @@ public class XPathConditional implements IConditionExpr {
         return triggers;
     }
 
-    private static void getTriggers(XPathExpression x, Vector<TreeReference> v, TreeReference contextRef) {
+    private static void getTriggers(XPathExpression x, Vector<TreeReference> v,
+            TreeReference contextRef) {
         if (x instanceof XPathPathExpr) {
             TreeReference ref = ((XPathPathExpr)x).getReference();
             TreeReference contextualized = ref;
@@ -109,7 +110,8 @@ public class XPathConditional implements IConditionExpr {
                 contextualized = ref.contextualize(contextRef);
             }
 
-            //TODO: It's possible we should just handle this the same way as "genericize". Not entirely clear.
+            // TODO: It's possible we should just handle this the same way as
+            // "genericize". Not entirely clear.
             if (contextualized.hasPredicates()) {
                 contextualized = contextualized.removePredicates();
             }

--- a/core/src/org/javarosa/xpath/XPathConditional.java
+++ b/core/src/org/javarosa/xpath/XPathConditional.java
@@ -102,7 +102,7 @@ public class XPathConditional implements IConditionExpr {
     }
 
     private static void getTriggers(XPathExpression x, Vector<TreeReference> v,
-            TreeReference contextRef) {
+                                    TreeReference contextRef) {
         if (x instanceof XPathPathExpr) {
             TreeReference ref = ((XPathPathExpr)x).getReference();
             TreeReference contextualized = ref;

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -325,13 +325,13 @@ public class TreeReferenceTest extends TestCase {
                 wildA.extendRef("c", TreeReference.INDEX_UNBOUND).equals(contextualizeEval));
 
         // ('../*').contextualize('/a/c') ==> /a/*/
-        // XXX: what should the behavoir for this be?
-        //      /a/c or /a/*
+        // NOTE: It's unclear what should the behavoir for this be: /a/c or /a/*
+        //       For now we will leave the code untouched and expect a/c
         TreeReference wildBack = XPathReference.getPathExpr("../*").getReference();
         contextualizeEval = wildBack.contextualize(acRef);
-        assertTrue("Got " + contextualizeEval.toString() + " and expected /a/*/" +
+        assertTrue("Got " + contextualizeEval.toString() + " and expected /a/c" +
                         " for test of wildcard merging",
-                wildA.equals(contextualizeEval));
+                acRef.genericize().equals(contextualizeEval.genericize()));
 
         // ('../a[6]').contextualize('/a/*/a') ==> /a/*/a[6]
         TreeReference wildAs = XPathReference.getPathExpr("/a/*").getReference();

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -39,6 +39,7 @@ public class TreeReferenceTest extends TestCase {
     TreeReference ace;
     TreeReference bc;
     TreeReference dotc;
+    TreeReference parentRef;
 
     TreeReference dot;
 
@@ -77,6 +78,10 @@ public class TreeReferenceTest extends TestCase {
 
         dot = TreeReference.selfRef();
         dotc = dot.extendRef("c", TreeReference.DEFAULT_MUTLIPLICITY);
+
+        // represent ../
+        parentRef = TreeReference.selfRef();
+        parentRef.incrementRefLevel();
 
         a2 = root.extendRef("a", 2);
         a2ext = root.extendRef("a", -1);
@@ -156,7 +161,12 @@ public class TreeReferenceTest extends TestCase {
             fail("(/a/c/d).subreference(0) should be: /a");
         }
         if (!ac.equals(acd.getSubReference(1))) {
-            fail("(/a/b/c).subreference(1) should be: /a/c");
+            fail("(/a/c/d).subreference(1) should be: /a/c");
+        }
+        try {
+            parentRef.getSubReference(0);
+            fail("(../).subreference(0) should throw an exception");
+        } catch (IllegalArgumentException e) {
         }
     }
 

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -272,13 +272,13 @@ public class TreeReferenceTest extends TestCase {
         // ('c').contextualize('/a/b') ==> /a/b/c
         contextualizeEval = floatc.contextualize(abRef);
         assertTrue("context: c didn't evaluate to " + abcRef.toString() +
-                ", but rather to " + contextualizeEval.toString(),
+                        ", but rather to " + contextualizeEval.toString(),
                 abcRef.equals(contextualizeEval));
 
         // ('./c').contextualize('/a/b') ==> /a/b/c
         contextualizeEval = floatc2.contextualize(abRef);
         assertTrue("context: ./c didn't evaluate to " + abcRef.toString() +
-                ", but rather to " + contextualizeEval.toString(),
+                        ", but rather to " + contextualizeEval.toString(),
                 abcRef.equals(contextualizeEval));
 
         // TODO: investigate why this test fails when acRef is used instead of
@@ -286,7 +286,7 @@ public class TreeReferenceTest extends TestCase {
         // ('../c').contextualize('/a/b') ==> /a/c
         contextualizeEval = backc.contextualize(abRef);
         assertTrue("context: ../c didn't evaluate to " + ac2Ref.toString() +
-                ", but rather to " + contextualizeEval.toString(),
+                        ", but rather to " + contextualizeEval.toString(),
                 ac2Ref.equals(contextualizeEval));
 
         // ('c').contextualize('./c') ==> null
@@ -297,7 +297,7 @@ public class TreeReferenceTest extends TestCase {
         // ('a[-1]').contextualize('a[2]') ==> something like a[position() != 2]
         contextualizeEval = a2extRef.contextualize(a2Ref);
         assertTrue("Treeref from named instance wrongly accepted multiplicity " +
-                "context from root instance",
+                        "context from root instance",
                 contextualizeEval.getMultLast() != 2);
 
         // Two tests trying to figure out multiplicity copying during
@@ -314,14 +314,14 @@ public class TreeReferenceTest extends TestCase {
         // ('../../a[6]').contextualize('/a[2]/a[3]/a[4]') ==> /a[2]/a[6]
         contextualizeEval = a5.contextualize(aaa);
         assertTrue("Got " + contextualizeEval.toString() + " and expected /a[2]/a[6]" +
-                " for test of multiplicity copying when level names are same between refs",
+                        " for test of multiplicity copying when level names are same between refs",
                 expectedAs.equals(contextualizeEval));
 
         // ('c').contextualize('/a/*') ==> /a/*/c
         TreeReference wildA = XPathReference.getPathExpr("/a/*").getReference();
         contextualizeEval = floatc.contextualize(wildA);
         assertTrue("Got " + contextualizeEval.toString() + " and expected /a/*/c" +
-                " for test of wildcard merging",
+                        " for test of wildcard merging",
                 wildA.extendRef("c", TreeReference.INDEX_UNBOUND).equals(contextualizeEval));
 
         // ('../*').contextualize('/a/c') ==> /a/*/
@@ -330,7 +330,7 @@ public class TreeReferenceTest extends TestCase {
         TreeReference wildBack = XPathReference.getPathExpr("../*").getReference();
         contextualizeEval = wildBack.contextualize(acRef);
         assertTrue("Got " + contextualizeEval.toString() + " and expected /a/*/" +
-                " for test of wildcard merging",
+                        " for test of wildcard merging",
                 wildA.equals(contextualizeEval));
 
         // ('../a[6]').contextualize('/a/*/a') ==> /a/*/a[6]
@@ -340,7 +340,7 @@ public class TreeReferenceTest extends TestCase {
         contextualizeEval = a5.contextualize(wildAs);
         expectedAs = XPathReference.getPathExpr("/a/*").getReference().extendRef("a", 5);
         assertTrue("Got " + contextualizeEval.toString() + " and expected /a/*/a[6]" +
-                " for test of multiplicity copying when level names are same between refs",
+                        " for test of multiplicity copying when level names are same between refs",
                 expectedAs.equals(contextualizeEval));
 
 
@@ -377,7 +377,7 @@ public class TreeReferenceTest extends TestCase {
         TreeReference azRef = XPathReference.getPathExpr("/a/z").getReference();
         anchorEval = wildBack.anchor(azRef);
         assertTrue("Got " + anchorEval.toString() + " and expected " + wildA.toString() +
-                " for anchoring with wildcards",
+                        " for anchoring with wildcards",
                 wildA.equals(anchorEval));
     }
 
@@ -397,19 +397,19 @@ public class TreeReferenceTest extends TestCase {
         // ('../c').parent('../c') ==> null
         parentEval = backc.parent(backc);
         assertTrue("The argument to calling 'parent' on a relative reference " +
-                "must be a series of ../'s with no reference level data",
+                        "must be a series of ../'s with no reference level data",
                 parentEval == null);
 
         // ('../c').parent('../') ==> '../../c/'
         parentEval = backc.parent(parentRef);
         assertTrue("calling 'parent' on a relative reference with ../'s should join " +
-                "them with those of the level-less relative argument reference.",
+                        "them with those of the level-less relative argument reference.",
                 back2c.equals(parentEval));
 
         // ('./c').parent('/a/b') ==> '/a/b/c'
         parentEval = floatc.parent(abRef);
         assertTrue("standard call to 'parent' returned " + parentEval.toString() +
-                "instead of expected /a/b/c",
+                        "instead of expected /a/b/c",
                 abcRef.equals(parentEval));
     }
 
@@ -437,7 +437,7 @@ public class TreeReferenceTest extends TestCase {
     private void testGenericize() {
         // Generic ref to generic attribute
         TreeReference attributeRef =
-            XPathReference.getPathExpr("/data/node/@attribute").getReference();
+                XPathReference.getPathExpr("/data/node/@attribute").getReference();
 
         // re-genericize
         TreeReference genericRef = attributeRef.genericize();

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -31,24 +31,24 @@ import org.javarosa.xpath.parser.XPathSyntaxException;
 
 public class TreeReferenceTest extends TestCase {
 
-    TreeReference root;
-    TreeReference a;
-    TreeReference b;
-    TreeReference ac;
-    TreeReference acd;
-    TreeReference ace;
-    TreeReference bc;
-    TreeReference dotc;
-    TreeReference parentRef;
+    private TreeReference root;
+    private TreeReference aRef;
+    private TreeReference bRef;
+    private TreeReference acRef;
+    private TreeReference acdRef;
+    private TreeReference aceRef;
+    private TreeReference bcRef;
+    private TreeReference dotcRef;
+    private TreeReference parentRef;
 
-    TreeReference dot;
+    private TreeReference dotRef;
 
-    TreeReference a2;
-    TreeReference a2ext;
+    private TreeReference a2Ref;
+    private TreeReference a2extRef;
 
-    TreeReference apred;
-    TreeReference apredmatch;
-    TreeReference aprednot;
+    private TreeReference apredRef;
+    private TreeReference apredmatchRef;
+    private TreeReference aprednotRef;
 
 
     public TreeReferenceTest(String name, TestMethod rTestMethod) {
@@ -68,41 +68,41 @@ public class TreeReferenceTest extends TestCase {
 
     private void initStuff() {
         root = TreeReference.rootRef();
-        a = root.extendRef("a", TreeReference.DEFAULT_MUTLIPLICITY);
-        b = root.extendRef("b", TreeReference.DEFAULT_MUTLIPLICITY);
-        ac = a.extendRef("c", TreeReference.DEFAULT_MUTLIPLICITY);
-        bc = b.extendRef("c", TreeReference.DEFAULT_MUTLIPLICITY);
+        aRef = root.extendRef("a", TreeReference.DEFAULT_MUTLIPLICITY);
+        bRef = root.extendRef("b", TreeReference.DEFAULT_MUTLIPLICITY);
+        acRef = aRef.extendRef("c", TreeReference.DEFAULT_MUTLIPLICITY);
+        bcRef = bRef.extendRef("c", TreeReference.DEFAULT_MUTLIPLICITY);
 
-        acd = ac.extendRef("d", TreeReference.DEFAULT_MUTLIPLICITY);
-        ace = ac.extendRef("e", TreeReference.DEFAULT_MUTLIPLICITY);
+        acdRef = acRef.extendRef("d", TreeReference.DEFAULT_MUTLIPLICITY);
+        aceRef = acRef.extendRef("e", TreeReference.DEFAULT_MUTLIPLICITY);
 
-        dot = TreeReference.selfRef();
-        dotc = dot.extendRef("c", TreeReference.DEFAULT_MUTLIPLICITY);
+        dotRef = TreeReference.selfRef();
+        dotcRef = dotRef.extendRef("c", TreeReference.DEFAULT_MUTLIPLICITY);
 
         // represent ../
         parentRef = TreeReference.selfRef();
         parentRef.incrementRefLevel();
 
-        a2 = root.extendRef("a", 2);
-        a2ext = root.extendRef("a", -1);
-        a2ext.setInstanceName("external");
+        a2Ref = root.extendRef("a", 2);
+        a2extRef = root.extendRef("a", -1);
+        a2extRef.setInstanceName("external");
 
-        apred = a.clone();
-        apredmatch = a.clone();
-        aprednot = a.clone();
+        apredRef = aRef.clone();
+        apredmatchRef = aRef.clone();
+        aprednotRef = aRef.clone();
 
         try {
             Vector<XPathExpression> apreds = new Vector<XPathExpression>();
             apreds.add(XPathParseTool.parseXPath("../b = 'test'"));
-            apred.addPredicate(0, apreds);
+            apredRef.addPredicate(0, apreds);
 
             Vector<XPathExpression> amatchpreds = new Vector<XPathExpression>();
             amatchpreds.add(XPathParseTool.parseXPath("../b = 'test'"));
-            apredmatch.addPredicate(0, amatchpreds);
+            apredmatchRef.addPredicate(0, amatchpreds);
 
             Vector<XPathExpression> anotpreds = new Vector<XPathExpression>();
             anotpreds.add(XPathParseTool.parseXPath("../b = 'fail'"));
-            aprednot.addPredicate(0, anotpreds);
+            aprednotRef.addPredicate(0, anotpreds);
         } catch (XPathSyntaxException e) {
             fail("Bad tests! Rewrite xpath expressions for predicate tests");
         }
@@ -157,10 +157,10 @@ public class TreeReferenceTest extends TestCase {
 
 
     private void testSubreferences() {
-        if (!a.equals(acd.getSubReference(0))) {
+        if (!aRef.equals(acdRef.getSubReference(0))) {
             fail("(/a/c/d).subreference(0) should be: /a");
         }
-        if (!ac.equals(acd.getSubReference(1))) {
+        if (!acRef.equals(acdRef.getSubReference(1))) {
             fail("(/a/c/d).subreference(1) should be: /a/c");
         }
         try {
@@ -176,67 +176,67 @@ public class TreeReferenceTest extends TestCase {
 
 
     private void testParentage() {
-        if (!root.isParentOf(a, true)) {
+        if (!root.isParentOf(aRef, true)) {
             fail("/ is a parent of '/a'");
         }
         ;
-        if (!a.isParentOf(ac, true)) {
+        if (!aRef.isParentOf(acRef, true)) {
             fail("/a is a parent of '/a/c'");
         }
         ;
-        if (!a.isParentOf(acd, true)) {
+        if (!aRef.isParentOf(acdRef, true)) {
             fail("a is a parent of 'a/c/d'");
         }
         ;
-        if (a.isParentOf(bc, true)) {
+        if (aRef.isParentOf(bcRef, true)) {
             fail("/a is not parent of '/b/c'");
         }
         ;
 
-        if (a.isParentOf(dotc, true)) {
+        if (aRef.isParentOf(dotcRef, true)) {
             fail("/a is not parent of './c'");
         }
         ;
     }
 
     private void testClones() {
-        if (!a.clone().equals(a)) {
+        if (!aRef.clone().equals(aRef)) {
             fail("/a was unable to clone properly");
         }
-        if (!ac.clone().equals(ac)) {
+        if (!acRef.clone().equals(acRef)) {
             fail("/a/c was unable to clone properly");
         }
-        if (!dot.clone().equals(dot)) {
+        if (!dotRef.clone().equals(dotRef)) {
             fail(". was unable to clone properly");
         }
-        if (!dotc.clone().equals(dotc)) {
+        if (!dotcRef.clone().equals(dotcRef)) {
             fail("./c was unable to clone properly");
         }
     }
 
     private void testIntersection() {
-        if (!a.intersect(a).equals(a)) {
+        if (!aRef.intersect(aRef).equals(aRef)) {
             fail("intersect(/a,/a) should result in /a");
         }
-        if (!ac.intersect(ac).equals(ac)) {
+        if (!acRef.intersect(acRef).equals(acRef)) {
             fail("intersect(/a/c,/a/c) should result in /a/c");
         }
-        if (!a.intersect(dot).equals(root)) {
+        if (!aRef.intersect(dotRef).equals(root)) {
             fail("intersect(/a,.) should result in /");
         }
-        if (!ac.intersect(a).equals(a)) {
+        if (!acRef.intersect(aRef).equals(aRef)) {
             fail("intersect(/a/c,/a) should result in /a");
         }
-        if (!a.intersect(ac).equals(a)) {
+        if (!aRef.intersect(acRef).equals(aRef)) {
             fail("intersect(/a,/a/c) should result in /a");
         }
-        if (!ace.intersect(acd).equals(ac)) {
+        if (!aceRef.intersect(acdRef).equals(acRef)) {
             fail("intersect(/a/c/d,/a/c/e) should result in /a/c");
         }
-        if (!ace.intersect(b).equals(root)) {
+        if (!aceRef.intersect(bRef).equals(root)) {
             fail("intersect(/a/c/e, /b) should result in /");
         }
-        if (!dot.intersect(dot).equals(root)) {
+        if (!dotRef.intersect(dotRef).equals(root)) {
             fail("intersect(.,.) should result in /");
         }
     }
@@ -269,17 +269,17 @@ public class TreeReferenceTest extends TestCase {
             fail("was succesfully able to contextualize against an ambiguous reference. Result was: " + invalid.toString(true));
         }
 
-        TreeReference a2extc = a2ext.contextualize(a2);
+        TreeReference a2extc = a2extRef.contextualize(a2Ref);
         if (a2extc.getMultLast() == 2) {
             fail("Treeref from named instance wrongly accepted multiplicity context from root instance");
         }
     }
 
     private void testPredicates() {
-        if (!apred.equals(apredmatch)) {
+        if (!apredRef.equals(apredmatchRef)) {
             fail("/a[..b = 'test'] Did not equal itself!");
         }
-        if (apred.equals(aprednot)) {
+        if (apredRef.equals(aprednotRef)) {
             fail("/a[..b = 'test'] was equal to /a[..b = 'fail']");
         }
     }
@@ -298,20 +298,20 @@ public class TreeReferenceTest extends TestCase {
                     " to " + genericRef.toString(true));
         }
 
-        // (/data/a[3]).genericize() ==> /data/a (with a's multiplicity being -1)
-        if (!a.genericize().equals(a2.genericize())) {
+        // (/data/aRef[3]).genericize() ==> /data/aRef (with aRef's multiplicity being -1)
+        if (!aRef.genericize().equals(a2Ref.genericize())) {
             fail("Genericize improperly converted removed multiplicities of " + 
-                    a2.toString(true) +
+                    a2Ref.toString(true) +
                     ", which should, once genericized, should match" +
-                    a.genericize().toString(true));
+                    aRef.genericize().toString(true));
         }
-        // (/data/a[3]).genericize() ==> /data/a (with a's multiplicity being -1)
-        // but 'a' in aRef should have the default multiplicity of 0
-        if (a.equals(a2.genericize())) {
+        // (/data/aRef[3]).genericize() ==> /data/aRef (with aRef's multiplicity being -1)
+        // but 'aRef' in aRef should have the default multiplicity of 0
+        if (aRef.equals(a2Ref.genericize())) {
             fail("Genericize improperly converted removed multiplicities of " + 
-                    a2.toString(true) +
+                    a2Ref.toString(true) +
                     ", which should, once genericized, should match" +
-                    a.toString(true));
+                    aRef.toString(true));
         }
     }
 }

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -241,23 +241,25 @@ public class TreeReferenceTest extends TestCase {
 
         TreeReference invalid = floatc.contextualize(floatc2);
 
-        if (!abc.equals(testabc)) {
-            fail("context: c didn't evaluate to " + abc.toString(true) + ", but rather to " + testabc.toString(true));
-        }
-        if (!abc.equals(testabc2)) {
-            fail("context: ./c didn't evaluate to " + abc.toString(true) + ", but rather to " + testabc2.toString(true));
-        }
-        if (!ac.equals(testac)) {
-            fail("context: ../c didn't evaluate to " + ac.toString(true) + ", but rather to " + testac.toString(true));
-        }
-        if (invalid != null) {
-            fail("was succesfully able to contextualize against an ambiguous reference. Result was: " + invalid.toString(true));
-        }
+        assertTrue("context: c didn't evaluate to " + abc.toString(true) +
+                ", but rather to " + testabc.toString(true),
+                abc.equals(testabc));
+
+        assertTrue("context: ./c didn't evaluate to " + abc.toString(true) +
+                ", but rather to " + testabc2.toString(true),
+                abc.equals(testabc2));
+
+        assertTrue("context: ../c didn't evaluate to " + ac.toString(true) +
+                ", but rather to " + testac.toString(true),
+                ac.equals(testac));
+
+        assertTrue("Was succesfully able to contextualize against an ambiguous reference.",
+                invalid == null);
 
         TreeReference a2extc = a2extRef.contextualize(a2Ref);
-        if (a2extc.getMultLast() == 2) {
-            fail("Treeref from named instance wrongly accepted multiplicity context from root instance");
-        }
+        assertTrue("Treeref from named instance wrongly accepted multiplicity " +
+                "context from root instance",
+                a2extc.getMultLast() != 2);
     }
 
     private void testPredicates() {

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -46,9 +46,9 @@ public class TreeReferenceTest extends TestCase {
     private TreeReference a2Ref;
     private TreeReference a2extRef;
 
-    private TreeReference apredRef;
-    private TreeReference apredmatchRef;
-    private TreeReference aprednotRef;
+    private TreeReference acPredRef;
+    private TreeReference acPredMatchRef;
+    private TreeReference acPredNotRef;
 
 
     public TreeReferenceTest(String name, TestMethod rTestMethod) {
@@ -87,25 +87,10 @@ public class TreeReferenceTest extends TestCase {
         a2extRef = root.extendRef("a", -1);
         a2extRef.setInstanceName("external");
 
-        apredRef = aRef.clone();
-        apredmatchRef = aRef.clone();
-        aprednotRef = aRef.clone();
+        acPredRef = acRef.clone();
+        acPredMatchRef = acRef.clone();
+        acPredNotRef = acRef.clone();
 
-        try {
-            Vector<XPathExpression> apreds = new Vector<XPathExpression>();
-            apreds.add(XPathParseTool.parseXPath("../b = 'test'"));
-            apredRef.addPredicate(0, apreds);
-
-            Vector<XPathExpression> amatchpreds = new Vector<XPathExpression>();
-            amatchpreds.add(XPathParseTool.parseXPath("../b = 'test'"));
-            apredmatchRef.addPredicate(0, amatchpreds);
-
-            Vector<XPathExpression> anotpreds = new Vector<XPathExpression>();
-            anotpreds.add(XPathParseTool.parseXPath("../b = 'fail'"));
-            aprednotRef.addPredicate(0, anotpreds);
-        } catch (XPathSyntaxException e) {
-            fail("Bad tests! Rewrite xpath expressions for predicate tests");
-        }
 
     }
 
@@ -276,12 +261,44 @@ public class TreeReferenceTest extends TestCase {
     }
 
     private void testPredicates() {
-        if (!apredRef.equals(apredmatchRef)) {
-            fail("/a[..b = 'test'] Did not equal itself!");
+        XPathExpression testPred = null;
+        XPathExpression failPred = null;
+        try {
+            testPred = XPathParseTool.parseXPath("../b = 'test'");
+            failPred = XPathParseTool.parseXPath("../b = 'fail'");
+        } catch (XPathSyntaxException e) {
+            fail("Bad tests! Rewrite xpath expressions for predicate tests");
         }
-        if (apredRef.equals(aprednotRef)) {
-            fail("/a[..b = 'test'] was equal to /a[..b = 'fail']");
-        }
+
+        Vector<XPathExpression> apreds = new Vector<XPathExpression>();
+        Vector<XPathExpression> amatchpreds = new Vector<XPathExpression>();
+        Vector<XPathExpression> anotpreds = new Vector<XPathExpression>();
+
+        apreds.add(testPred);
+        amatchpreds.add(testPred);
+        anotpreds.add(failPred);
+
+        acPredRef.addPredicate(0, apreds);
+        acPredMatchRef.addPredicate(0, amatchpreds);
+        acPredNotRef.addPredicate(0, anotpreds);
+
+        assertTrue("Predicates weren't correctly removed from reference.",
+                !acPredRef.removePredicates().hasPredicates());
+
+        assertTrue("Predicates weren't correctly detected.",
+                acPredRef.hasPredicates());
+
+        assertTrue("Found predicates where they shouldn't be.",
+                acPredRef.getPredicate(1) == null);
+
+        assertTrue("Didn't find predicates where they should be.",
+                acPredRef.getPredicate(0) == apreds);
+
+        assertTrue("/a[..b = 'test'] Did not equal itself!",
+                acPredRef.equals(acPredMatchRef));
+
+        assertTrue("/a[..b = 'test'] was equal to /a[..b = 'fail']",
+                !acPredRef.equals(acPredNotRef));
     }
 
 

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -66,7 +66,7 @@ public class TreeReferenceTest extends TestCase {
         initStuff();
     }
 
-    public void initStuff() {
+    private void initStuff() {
         root = TreeReference.rootRef();
         a = root.extendRef("a", TreeReference.DEFAULT_MUTLIPLICITY);
         b = root.extendRef("b", TreeReference.DEFAULT_MUTLIPLICITY);
@@ -124,9 +124,9 @@ public class TreeReferenceTest extends TestCase {
         return aSuite;
     }
 
-    public final static int NUM_TESTS = 8;
+    private final static int NUM_TESTS = 8;
 
-    public void doTest(int i) {
+    private void doTest(int i) {
         switch (i) {
             case 1:
                 testClones();
@@ -170,12 +170,12 @@ public class TreeReferenceTest extends TestCase {
         }
     }
 
-    public void testSerialization() {
+    private void testSerialization() {
         //TODO: That ^
     }
 
 
-    public void testParentage() {
+    private void testParentage() {
         if (!root.isParentOf(a, true)) {
             fail("/ is a parent of '/a'");
         }
@@ -199,7 +199,7 @@ public class TreeReferenceTest extends TestCase {
         ;
     }
 
-    public void testClones() {
+    private void testClones() {
         if (!a.clone().equals(a)) {
             fail("/a was unable to clone properly");
         }
@@ -214,7 +214,7 @@ public class TreeReferenceTest extends TestCase {
         }
     }
 
-    public void testIntersection() {
+    private void testIntersection() {
         if (!a.intersect(a).equals(a)) {
             fail("intersect(/a,/a) should result in /a");
         }
@@ -241,7 +241,7 @@ public class TreeReferenceTest extends TestCase {
         }
     }
 
-    public void contextualization() {
+    private void contextualization() {
         TreeReference abc = XPathReference.getPathExpr("/a/b/c").getReference();
         TreeReference ab = XPathReference.getPathExpr("/a/b").getReference();
         TreeReference ac = XPathReference.getPathExpr("/a/c").getReference();
@@ -275,7 +275,7 @@ public class TreeReferenceTest extends TestCase {
         }
     }
 
-    public void testPredicates() {
+    private void testPredicates() {
         if (!apred.equals(apredmatch)) {
             fail("/a[..b = 'test'] Did not equal itself!");
         }
@@ -286,15 +286,32 @@ public class TreeReferenceTest extends TestCase {
 
 
     private void testGenericize() {
-        //Generic ref to generic attribute
-        TreeReference attributeRef = XPathReference.getPathExpr("/data/node/@attribute").getReference();
+        // Generic ref to generic attribute
+        TreeReference attributeRef =
+            XPathReference.getPathExpr("/data/node/@attribute").getReference();
 
-        //re-genericize
+        // re-genericize
         TreeReference genericRef = attributeRef.genericize();
 
         if (!attributeRef.equals(genericRef)) {
-            fail("Genericize improperly converted " + attributeRef.toString(true) + " to " + genericRef.toString(true));
+            fail("Genericize improperly converted " + attributeRef.toString(true) +
+                    " to " + genericRef.toString(true));
+        }
+
+        // (/data/a[3]).genericize() ==> /data/a (with a's multiplicity being -1)
+        if (!a.genericize().equals(a2.genericize())) {
+            fail("Genericize improperly converted removed multiplicities of " + 
+                    a2.toString(true) +
+                    ", which should, once genericized, should match" +
+                    a.genericize().toString(true));
+        }
+        // (/data/a[3]).genericize() ==> /data/a (with a's multiplicity being -1)
+        // but 'a' in aRef should have the default multiplicity of 0
+        if (a.equals(a2.genericize())) {
+            fail("Genericize improperly converted removed multiplicities of " + 
+                    a2.toString(true) +
+                    ", which should, once genericized, should match" +
+                    a.toString(true));
         }
     }
 }
-


### PR DESCRIPTION
In prep for working on some reference related bugs I'm reading through code, cleaning up comments and adding tests

I've noted changes that are worthy of a 2nd look