### PR TITLE
Current and original context fix

### DIFF
--- a/core/resources/trigger_and_current_tests.xml
+++ b/core/resources/trigger_and_current_tests.xml
@@ -1,0 +1,44 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms"
+        xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Bad Constraint Propagation</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+                      xmlns="http://openrosa.org/formdesigner/C1417AEE-F51D-4BA6-9769-381896D4CB9F"
+                      uiVersion="1" version="1" name="Bad Constraint Propagation">
+                    <show>yes</show>
+                    <display/>
+                </data>
+            </instance>
+
+            <instance id="alternate">
+                <root>
+                    <show id="id">yes</show>
+                </root>
+            </instance>
+
+            <bind nodeset="/data/display"
+                  relevant="count(instance('alternate')/root/show[@id='id'][. = current()/../show]) &gt; 0"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/data/show">
+            <label>Display the next label?</label>
+            <item>
+                <label>Yes</label>
+                <value>yes</value>
+            </item>
+            <item>
+                <label>No</label>
+                <value>no</value>
+            </item>
+        </select1>
+        <trigger ref="/data/display">
+            <label>Should this label have been displayed?:
+                <output ref="/data/show"/>
+            </label>
+        </trigger>
+    </h:body>
+</h:html>

--- a/core/src/org/javarosa/core/model/FormDef.java
+++ b/core/src/org/javarosa/core/model/FormDef.java
@@ -134,7 +134,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         setChildren(null);
         triggerables = new Vector();
         triggerablesInOrder = true;
-        triggerIndex = new Hashtable();
+        triggerIndex = new Hashtable<TreeReference, Vector<Triggerable>>();
         //This is kind of a wreck...
         setEvaluationContext(new EvaluationContext(null));
         outputFragments = new Vector();
@@ -543,7 +543,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      */
     public Triggerable addTriggerable(Triggerable t) {
         int existingIx = triggerables.indexOf(t);
-        if (existingIx >= 0) {
+        if (existingIx != -1) {
             // One node may control access to many nodes; this means many nodes
             // effectively have the same condition. Let's identify when
             // conditions are the same, and store and calculate it only once.
@@ -567,11 +567,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             triggerables.addElement(t);
             triggerablesInOrder = false;
 
-            Vector triggers = t.getTriggers();
-            for (int i = 0; i < triggers.size(); i++) {
-                TreeReference trigger = (TreeReference)triggers.elementAt(i);
+            for (TreeReference trigger : t.getTriggers()) {
                 if (!triggerIndex.containsKey(trigger)) {
-                    triggerIndex.put(trigger.clone(), new Vector());
+                    triggerIndex.put(trigger.clone(), new Vector<Triggerable>());
                 }
                 Vector triggered = (Vector)triggerIndex.get(trigger);
                 if (!triggered.contains(t)) {
@@ -682,6 +680,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * triggerable is fired.
      *
      * @param t
+     * @param destination
      */
     public void fillTriggeredElements(Triggerable t, Vector<Triggerable> destination) {
         if (t.canCascade()) {

--- a/core/src/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/core/src/org/javarosa/core/model/condition/EvaluationContext.java
@@ -53,6 +53,7 @@ public class EvaluationContext {
 
     private Hashtable<String, DataInstance> formInstances;
 
+    // original context reference used for evaluating current()
     private TreeReference original;
     private int currentContextPosition = -1;
 
@@ -392,23 +393,38 @@ public class EvaluationContext {
         }
     }
 
-    private EvaluationContext rescope(TreeReference treeRef, int currentContextPosition) {
-        EvaluationContext ec = new EvaluationContext(this, treeRef);
-        ec.currentContextPosition = currentContextPosition;
-        //If there was no original context position, we'll want to set the next original
-        //context to be this rescoping (which would be the backup original one).
+    /**
+     * Create a copy of the evaluation context, with a new context ref. 
+     *
+     * When determining what the original reference field of the new object
+     * should be:
+     *  - Use the 'original' field from the original object.
+     *  - If it is unset, use the original objects context reference.
+     *  - If that is '/' then use the new context reference
+     *
+     * @param newContextRef the new context anchor reference
+     * @param newContextPosition the new position of the context (in a repeat
+     *                           group)
+     * @return a copy of this evaluation context, with a new context reference
+     *         set and the original context reference correspondingly updated.
+     */
+    private EvaluationContext rescope(TreeReference newContextRef, int newContextPosition) {
+        EvaluationContext ec = new EvaluationContext(this, newContextRef);
+        ec.currentContextPosition = newContextPosition;
+
+        // If we have an original context reference, use it
         if (this.original != null) {
             ec.setOriginalContext(this.getOriginalContext());
         } else {
-            //Check to see if we have a context, if not, the treeRef is the original declared
-            //nodeset.
-            if (TreeReference.rootRef().equals(this.getContextRef())) {
-                ec.setOriginalContext(treeRef);
-            } else {
-                //If we do have a legit context, use it!
+            // Otherwise, if the old context reference isn't '/', use that.If
+            // the context ref is '/', use the new context ref as the original
+            if (!TreeReference.rootRef().equals(this.getContextRef())) {
                 ec.setOriginalContext(this.getContextRef());
+            } else {
+                // Otherwise propagate the original context reference field
+                // with the new context reference argument
+                ec.setOriginalContext(newContextRef);
             }
-
         }
         return ec;
     }
@@ -425,6 +441,9 @@ public class EvaluationContext {
         return instance.resolveReference(qualifiedRef);
     }
 
+    /**
+     * What repeat item is the current context pointing to?
+     */
     public int getContextPosition() {
         return currentContextPosition;
     }

--- a/core/src/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/core/src/org/javarosa/core/model/condition/EvaluationContext.java
@@ -394,19 +394,19 @@ public class EvaluationContext {
     }
 
     /**
-     * Create a copy of the evaluation context, with a new context ref. 
+     * Create a copy of the evaluation context, with a new context ref.
      *
      * When determining what the original reference field of the new object
      * should be:
-     *  - Use the 'original' field from the original object.
-     *  - If it is unset, use the original objects context reference.
-     *  - If that is '/' then use the new context reference
+     * - Use the 'original' field from the original object.
+     * - If it is unset, use the original objects context reference.
+     * - If that is '/' then use the new context reference
      *
-     * @param newContextRef the new context anchor reference
+     * @param newContextRef      the new context anchor reference
      * @param newContextPosition the new position of the context (in a repeat
      *                           group)
      * @return a copy of this evaluation context, with a new context reference
-     *         set and the original context reference correspondingly updated.
+     * set and the original context reference correspondingly updated.
      */
     private EvaluationContext rescope(TreeReference newContextRef, int newContextPosition) {
         EvaluationContext ec = new EvaluationContext(this, newContextRef);

--- a/core/src/org/javarosa/core/model/condition/IConditionExpr.java
+++ b/core/src/org/javarosa/core/model/condition/IConditionExpr.java
@@ -83,9 +83,11 @@ public interface IConditionExpr extends Externalizable {
      * directly. These values can't be contextualized fully (since these triggers are necessary
      * before runtime), but should only need to be contextualized to be a complete set.
      *
-     * @return
+     * @param originalContextRef context reference pointing to the nodeset
+     *                           reference; used for expanding 'current()'
+     * @return References that are dependant on this expression's value.
      */
-    Vector<TreeReference> getTriggers(); /* vector of TreeReference */
+    Vector<TreeReference> getExprsTriggers(TreeReference originalContextRef);
 
     /**
      * Provide a list of Pivots around which this Condition Expression depends.

--- a/core/src/org/javarosa/core/model/condition/Triggerable.java
+++ b/core/src/org/javarosa/core/model/condition/Triggerable.java
@@ -139,7 +139,8 @@ public abstract class Triggerable implements Externalizable {
 
     public Vector<TreeReference> getTriggers() {
         // grab the relative trigger references from expression
-        Vector<TreeReference> relTriggers = expr.getTriggers();
+        Vector<TreeReference> relTriggers = expr.getExprsTriggers(originalContextRef);
+
         // construct absolute references by anchoring against the original context reference
         Vector<TreeReference> absTriggers = new Vector<TreeReference>();
         for (int i = 0; i < relTriggers.size(); i++) {

--- a/core/src/org/javarosa/xpath/XPathConditional.java
+++ b/core/src/org/javarosa/xpath/XPathConditional.java
@@ -104,17 +104,18 @@ public class XPathConditional implements IConditionExpr {
     /**
      * Recursive helper to getExprsTriggers with an accumulator trigger vector.
      *
-     * @param expr current expression we are collecting triggers from
-     * @param triggers accumulates the references that this object's expression value
-     *                 depends upon.
-     * @param contextRef use this updated context; used, for instance, when we
-     *                   move into handling predicates
-     * @param originalContextRef context reference pointing to the nodeset
+     * @param expr               Current expression we are collecting triggers from
+     * @param triggers           Accumulates the references that this object's
+     *                           expression value depends upon.
+     * @param contextRef         Use this updated context; used, for instance,
+     *                           when we move into handling predicates
+     * @param originalContextRef Context reference pointing to the nodeset
      *                           reference; used for expanding 'current()'
      */
     private static void getExprsTriggersAccumulator(XPathExpression expr,
-            Vector<TreeReference> triggers,
-            TreeReference contextRef, TreeReference originalContextRef) {
+                                                    Vector<TreeReference> triggers,
+                                                    TreeReference contextRef,
+                                                    TreeReference originalContextRef) {
         if (expr instanceof XPathPathExpr) {
             TreeReference ref = ((XPathPathExpr)expr).getReference();
             TreeReference contextualized = ref;

--- a/core/src/org/javarosa/xpath/XPathConditional.java
+++ b/core/src/org/javarosa/xpath/XPathConditional.java
@@ -95,18 +95,37 @@ public class XPathConditional implements IConditionExpr {
         }
     }
 
-    public Vector<TreeReference> getTriggers() {
+    public Vector<TreeReference> getExprsTriggers(TreeReference originalContextRef) {
         Vector triggers = new Vector();
-        getTriggers(expr, triggers, null);
+        getExprsTriggersAccumulator(expr, triggers, null, originalContextRef);
         return triggers;
     }
 
-    private static void getTriggers(XPathExpression x, Vector<TreeReference> v,
-                                    TreeReference contextRef) {
-        if (x instanceof XPathPathExpr) {
-            TreeReference ref = ((XPathPathExpr)x).getReference();
+    /**
+     * Recursive helper to getExprsTriggers with an accumulator trigger vector.
+     *
+     * @param expr current expression we are collecting triggers from
+     * @param triggers accumulates the references that this object's expression value
+     *                 depends upon.
+     * @param contextRef use this updated context; used, for instance, when we
+     *                   move into handling predicates
+     * @param originalContextRef context reference pointing to the nodeset
+     *                           reference; used for expanding 'current()'
+     */
+    private static void getExprsTriggersAccumulator(XPathExpression expr,
+            Vector<TreeReference> triggers,
+            TreeReference contextRef, TreeReference originalContextRef) {
+        if (expr instanceof XPathPathExpr) {
+            TreeReference ref = ((XPathPathExpr)expr).getReference();
             TreeReference contextualized = ref;
-            if (contextRef != null) {
+
+            if (ref.getContext() == TreeReference.CONTEXT_ORIGINAL) {
+                // Starts with 'current()' so contextualize in terms of the
+                // nodeset's original reference.
+                contextualized = ref.contextualize(originalContextRef);
+            } else if (contextRef != null) {
+                // If present then the context has been updated, so use it.
+                // Necessary if we jump into handling predicates.
                 contextualized = ref.contextualize(contextRef);
             }
 
@@ -115,9 +134,10 @@ public class XPathConditional implements IConditionExpr {
             if (contextualized.hasPredicates()) {
                 contextualized = contextualized.removePredicates();
             }
-            if (!v.contains(contextualized)) {
-                v.addElement(contextualized);
+            if (!triggers.contains(contextualized)) {
+                triggers.addElement(contextualized);
             }
+            // find the references this reference depends on inside of predicates
             for (int i = 0; i < ref.size(); i++) {
                 Vector<XPathExpression> predicates = ref.getPredicate(i);
                 if (predicates == null) {
@@ -131,18 +151,23 @@ public class XPathConditional implements IConditionExpr {
                 TreeReference predicateContext = ref.getSubReference(i);
 
                 for (XPathExpression predicate : predicates) {
-                    getTriggers(predicate, v, predicateContext);
+                    getExprsTriggersAccumulator(predicate, triggers,
+                            predicateContext, originalContextRef);
                 }
             }
-        } else if (x instanceof XPathBinaryOpExpr) {
-            getTriggers(((XPathBinaryOpExpr)x).a, v, contextRef);
-            getTriggers(((XPathBinaryOpExpr)x).b, v, contextRef);
-        } else if (x instanceof XPathUnaryOpExpr) {
-            getTriggers(((XPathUnaryOpExpr)x).a, v, contextRef);
-        } else if (x instanceof XPathFuncExpr) {
-            XPathFuncExpr fx = (XPathFuncExpr)x;
+        } else if (expr instanceof XPathBinaryOpExpr) {
+            getExprsTriggersAccumulator(((XPathBinaryOpExpr)expr).a, triggers,
+                    contextRef, originalContextRef);
+            getExprsTriggersAccumulator(((XPathBinaryOpExpr)expr).b, triggers,
+                    contextRef, originalContextRef);
+        } else if (expr instanceof XPathUnaryOpExpr) {
+            getExprsTriggersAccumulator(((XPathUnaryOpExpr)expr).a, triggers,
+                    contextRef, originalContextRef);
+        } else if (expr instanceof XPathFuncExpr) {
+            XPathFuncExpr fx = (XPathFuncExpr)expr;
             for (int i = 0; i < fx.args.length; i++)
-                getTriggers(fx.args[i], v, contextRef);
+                getExprsTriggersAccumulator(fx.args[i], triggers,
+                        contextRef, originalContextRef);
         }
     }
 

--- a/core/src/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/core/src/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -180,7 +180,9 @@ public class XPathPathExpr extends XPathExpression {
         TreeReference genericRef = getReference();
 
         TreeReference ref;
+
         if (genericRef.getContext() == TreeReference.CONTEXT_ORIGINAL) {
+            // reference begins with "current()" so contexutalize in the original context
             ref = genericRef.contextualize(ec.getOriginalContext());
         } else {
             ref = genericRef.contextualize(ec.getContextRef());

--- a/core/test/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/test/org/javarosa/core/model/test/FormDefTest.java
@@ -23,59 +23,49 @@ import j2meunit.framework.TestSuite;
 
 import org.javarosa.core.model.FormElementStateListener;
 import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.IDataReference;
 import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IntegerData;
+import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.javarosa.model.xform.XPathReference;
 
 /**
- * See testAnswerConstraint() for an example of how to write the
- * constraint unit type tests.
- *
- * @author adewinter
+ * @author Phillip Mates
  */
 public class FormDefTest extends TestCase {
-    QuestionDef q = null;
-    FormEntryPrompt fep = null;
     FormParseInit fpi = null;
 
     // How many tests does the suite have?
     // Used to dispatch in doTest's switch statement.
-    public final static int NUM_TESTS = 1;
+    public final static int NUM_TESTS = 2;
 
     public FormDefTest(String name, TestMethod rTestMethod) {
         super(name, rTestMethod);
-        initStuff();
+        initForm();
     }
 
     public FormDefTest(String name) {
         super(name);
-        initStuff();
+        initForm();
     }
 
     public FormDefTest() {
         super();
-        initStuff();
+        initForm();
     }
 
-    public void initStuff() {
+    public void initForm() {
         fpi = new FormParseInit();
-        q = fpi.getFirstQuestionDef();
-        fep = new FormEntryPrompt(fpi.getFormDef(), fpi.getFormEntryModel().getFormIndex());
-    }
-
-    static PrototypeFactory pf;
-
-    static {
-        PrototypeManager.registerPrototype("org.javarosa.model.xform.XPathReference");
-        pf = ExtUtil.defaultPrototypes();
     }
 
     public Test suite() {
@@ -93,28 +83,66 @@ public class FormDefTest extends TestCase {
         return aSuite;
     }
 
-    private void testSerialize(QuestionDef q, String msg) {
-        //ExternalizableTest.testExternalizable(q, this, pf, "QuestionDef [" + msg + "]");
-    }
-
     public void doTest(int i) {
         switch (i) {
             case 1:
                 testAnswerConstraint();
                 break;
+            case 2:
+                testCurrentFuncInTriggers();
+                break;
         }
     }
 
 
-    public void testAnswerConstraint() {
-        IntegerData ans = new IntegerData(13);
+    /**
+     * Make sure that 'current()' expands correctly when used in conditionals
+     * such as in 'relevant' tags. The test answers a question and expects the
+     * correct elements to be re-evaluated and set to not relevant.
+     */
+    public void testCurrentFuncInTriggers() {
+        String formName = new String("/trigger_and_current_tests.xml");
+        fpi.setFormToParse(formName);
+
         FormEntryController fec = fpi.getFormEntryController();
         fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
 
         do {
-
             QuestionDef q = fpi.getCurrentQuestion();
-            if (q == null || q.getTextID() == null || q.getTextID() == "") continue;
+            if (q == null) {
+                continue;
+            }
+            // get the reference of question
+            TreeReference qRef = (TreeReference)((XPathReference)q.getBind()).getReference();
+
+            // are we changing the value of /data/show?
+            if (qRef.toString().equals("/data/show")) {
+                int response = fec.answerQuestion(new StringData("no"));
+                if (response != fec.ANSWER_OK){
+                    fail("Bad response from fec.answerQuestion()");
+                }
+            } else if (q.getID() == 2) {
+                // check (sketchily) if the second question is shown, which
+                // shouldn't happen after answering "no" to the first, unless
+                // triggers aren't working properly.
+                fail("shouldn't be relevant after answering no before");
+            }
+        } while (fec.stepToNextEvent() != fec.EVENT_END_OF_FORM);
+    }
+
+    public void testAnswerConstraint() {
+        IntegerData ans = new IntegerData(13);
+        String formName = new String("/ImageSelectTester.xhtml");
+
+        fpi.setFormToParse(formName);
+        FormEntryController fec = fpi.getFormEntryController();
+        fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+
+        do {
+            QuestionDef q = fpi.getCurrentQuestion();
+            if (q == null || q.getTextID() == null || q.getTextID() == "") {
+                continue;
+            }
             if (q.getTextID().equals("constraint-test")) {
                 int response = fec.answerQuestion(ans);
                 if (response == fec.ANSWER_CONSTRAINT_VIOLATED) {

--- a/core/test/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/test/org/javarosa/core/model/test/FormDefTest.java
@@ -118,7 +118,7 @@ public class FormDefTest extends TestCase {
             // are we changing the value of /data/show?
             if (qRef.toString().equals("/data/show")) {
                 int response = fec.answerQuestion(new StringData("no"));
-                if (response != fec.ANSWER_OK){
+                if (response != fec.ANSWER_OK) {
                     fail("Bad response from fec.answerQuestion()");
                 }
             } else if (q.getID() == 2) {


### PR DESCRIPTION
Fixes bug where "current()" in the following tag doesn't expand to "/data/display":
<bind nodeset="/data/display" relevant="count(/data/a[@id='id'][. = current()/../show]) &gt; 0"/>


This occurred because XPathConditional.getTriggers() didn't propagate the "original" context, it only propagated the local context, so when identifying what node we should be referencing, the correct target of current() isn't available.

Depends on [PR 71](https://github.com/dimagi/javarosa/pull/71) being merged first

[FogBugz Ticket 112628](http://manage.dimagi.com/default.asp?112628)