### PR TITLE
Have 'contextualize' copy mult info.

### DIFF
--- a/core/src/org/javarosa/core/model/instance/DataInstance.java
+++ b/core/src/org/javarosa/core/model/instance/DataInstance.java
@@ -78,6 +78,10 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
         return false;
     }
 
+    public T resolveReference(XPathReference binding) {
+        return resolveReference(unpackReference(binding));
+    }
+
     public T resolveReference(TreeReference ref) {
         if (!ref.isAbsolute()) {
             return null;
@@ -256,10 +260,6 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
         }
         // no way forward
         return false;
-    }
-
-    public T resolveReference(XPathReference binding) {
-        return resolveReference(unpackReference(binding));
     }
 
     public void setFormId(int formId) {

--- a/core/src/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/org/javarosa/core/model/instance/TreeReference.java
@@ -417,7 +417,10 @@ public class TreeReference implements Externalizable {
     }
 
     /**
-     * Evaluate this reference in terms of the base reference argument.
+     * Evaluate this reference in terms of the base reference argument. If this
+     * reference can be made more specific by filters or predicates in the
+     * context reference, it does so, but never overwrites existing filters or
+     * predicates.
      *
      * @param contextRef the absolute reference used as the base while evaluating
      *                   this reference.
@@ -460,7 +463,14 @@ public class TreeReference implements Externalizable {
                 newRef.data.setElementAt(newRef.data.elementAt(i).setName(contextRef.getName(i)), i);
             }
 
-            if (!contextRef.getName(i).equals(newRef.getName(i))) {
+            if (contextRef.getName(i).equals(newRef.getName(i))) {
+                // Only copy over multiplicity info if it won't overwrite any
+                // existing preds or filters
+                if (newRef.getPredicate(i) == null &&
+                        newRef.getMultiplicity(i) == INDEX_UNBOUND) {
+                    newRef.setMultiplicity(i, contextRef.getMultiplicity(i));
+                }
+            } else {
                 break;
             }
         }

--- a/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
+++ b/core/test/org/javarosa/core/model/test/TreeReferenceTest.java
@@ -328,7 +328,7 @@ public class TreeReferenceTest extends TestCase {
         // contextualization.
 
         // Test trying to figure out multiplicity copying during contextualization
-        // setup ../../a[5] reference
+        // setup ../../a[6] reference
         TreeReference a5 = root.extendRef("a", 5);
         a5.setRefLevel(2);
 
@@ -340,6 +340,16 @@ public class TreeReferenceTest extends TestCase {
         assertTrue("Got " + contextualizeEval.toString() + " and expected /a[2]/a[6]" +
                         " for test of multiplicity copying when level names are same between refs",
                 expectedAs.equals(contextualizeEval));
+
+        // setup expected result /a[2]/a[3] reference
+        expectedAs = a.extendRef("a", 2);
+
+        // ('../../a').contextualize('/a[2]/a[3]/a[4]') ==> /a[2]/a[3]
+        contextualizeEval = a5.genericize().contextualize(aaa);
+        assertTrue("Got " + contextualizeEval.toString() + " and expected /a[2]/a[3]" +
+                        " for test of multiplicity copying when level names are same between refs",
+                expectedAs.equals(contextualizeEval));
+
 
         // ('c').contextualize('/a/*') ==> /a/*/c
         TreeReference wildA = XPathReference.getPathExpr("/a/*").getReference();


### PR DESCRIPTION
Fix contextualize to copy over multiplicity info from context reference if it will make the reference in question more specific, without overwriting existing multiplicity info.

Fixes [this ticket](http://manage.dimagi.com/default.asp?167350#932438)