### PR TITLE
Revert "Remove title println"

### DIFF
--- a/core/src/org/javarosa/xform/parse/XFormParser.java
+++ b/core/src/org/javarosa/xform/parse/XFormParser.java
@@ -676,6 +676,7 @@ public class XFormParser {
     private void parseTitle(Element e) {
         Vector usedAtts = new Vector(); //no attributes parsed in title.
         String title = getXMLText(e, true);
+        System.out.println("Title: \"" + title + "\"");
         _f.setTitle(title);
         if (_f.getName() == null) {
             //Jan 9, 2009 - ctsims


### PR DESCRIPTION
Reverts dimagi/javarosa#94
@wpride @ctsims 
Makes sense, I think muffling stdout is the way to go in touchforms then. Though it would be nice when it threw an error we had this info