### PR TITLE
use the old code to fallback more elegantly

### DIFF
--- a/core/src/org/javarosa/form/api/FormEntryPrompt.java
+++ b/core/src/org/javarosa/form/api/FormEntryPrompt.java
@@ -193,11 +193,22 @@ public class FormEntryPrompt extends FormEntryCaption {
         }
     }
 
+    public String getConstraintText(){
+        return getConstraintText(null);
+    }
+
     public String getConstraintText(IAnswerData attemptedValue) {
         return getConstraintText(null, attemptedValue);
     }
 
     public String getConstraintText(String textForm, IAnswerData attemptedValue) {
+        // new constraint spec uses "alert" form XForm spec 8.2.4
+        // http://www.w3.org/TR/xforms/#ui-commonelems
+        String newConstraintMsg =  this.localizeText(getQuestion().getQuestionString(XFormParser.CONSTRAINT_ELEMENT));
+        if(newConstraintMsg != null){
+            return newConstraintMsg;
+        }
+        // if doesn't exist, use the old logic
         if (mTreeElement.getConstraint() == null) {
             return null;
         } else {
@@ -211,26 +222,6 @@ public class FormEntryPrompt extends FormEntryCaption {
             }
             return mTreeElement.getConstraint().getConstraintMessage(ec, form.getMainInstance(), textForm);
         }
-    }
-
-    /**
-     * Convenience method
-     * Get longText form of text for THIS element (if available)
-     * !!Falls back to default form if 'long' form does not exist.!!
-     * Use getSpecialFormQuestionText() if you want short form only.
-     *
-     * @return longText form
-     */
-    public String getConstraintText() {
-        // new constraint spec uses "alert" form XForm spec 8.2.4
-        // http://www.w3.org/TR/xforms/#ui-commonelems
-        String newConstraintMsg =  this.localizeText(getQuestion().getQuestionString(XFormParser.CONSTRAINT_ELEMENT));
-        if(newConstraintMsg != null){
-            return newConstraintMsg;
-        }
-        // if not found, try to fall back to old jr:constraintMsg format http://www.w3.org/TR/xforms/#ui-commonelems
-        EvaluationContext ec = new EvaluationContext(form.exprEvalContext, mTreeElement.getRef());
-        return mTreeElement.getConstraint().getConstraintMessage(ec, form.getMainInstance(), null);
     }
 
     public Vector<SelectChoice> getSelectChoices() {

--- a/core/src/org/javarosa/form/api/FormEntryPrompt.java
+++ b/core/src/org/javarosa/form/api/FormEntryPrompt.java
@@ -198,16 +198,17 @@ public class FormEntryPrompt extends FormEntryCaption {
     }
 
     public String getConstraintText(IAnswerData attemptedValue) {
-        return getConstraintText(null, attemptedValue);
-    }
-
-    public String getConstraintText(String textForm, IAnswerData attemptedValue) {
         // new constraint spec uses "alert" form XForm spec 8.2.4
         // http://www.w3.org/TR/xforms/#ui-commonelems
         String newConstraintMsg =  this.localizeText(getQuestion().getQuestionString(XFormParser.CONSTRAINT_ELEMENT));
         if(newConstraintMsg != null){
             return newConstraintMsg;
         }
+        //default to old logic
+        return getConstraintText(null, attemptedValue);
+    }
+
+    public String getConstraintText(String textForm, IAnswerData attemptedValue) {
         // if doesn't exist, use the old logic
         if (mTreeElement.getConstraint() == null) {
             return null;


### PR DESCRIPTION
2.22 bug fix where we were crashing when the constraint message was being retrieved when it wasn't set. the existing code already had the logic for this, I just wasn't polymorphing correctly

http://manage.dimagi.com/default.asp?171245