### PR TITLE
Comments and field privatization for triggers

### DIFF
--- a/core/src/org/javarosa/core/model/FormDef.java
+++ b/core/src/org/javarosa/core/model/FormDef.java
@@ -545,8 +545,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     /**
      * Add a Condition to the form's Collection.
-     *
-     * @param condition the condition to be set
      */
     public Triggerable addTriggerable(Triggerable t) {
         int existingIx = triggerables.indexOf(t);

--- a/core/src/org/javarosa/core/model/FormDef.java
+++ b/core/src/org/javarosa/core/model/FormDef.java
@@ -98,7 +98,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     // This list is topologically ordered, meaning for any tA
     // and tB in the list, where tA comes before tB, evaluating tA cannot
     // depend on any result from evaluating tB
-    public Vector<Triggerable> triggerables;
+    private Vector<Triggerable> triggerables;
 
     // true if triggerables has been ordered topologically (DON'T DELETE ME
     // EVEN THOUGH I'M UNUSED)
@@ -109,7 +109,13 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     // arguments to captions
     private Vector outputFragments;
 
-    public Hashtable<TreeReference, Vector<Triggerable>> triggerIndex;
+    /**
+     * Map references to the calculate/relevancy conditions that depend on that
+     * reference's value. Used to trigger re-evaluation of those conditionals
+     * when the reference is updated.
+     */
+    private Hashtable<TreeReference, Vector<Triggerable>> triggerIndex;
+
     private Hashtable<TreeReference, Condition> conditionRepeatTargetIndex;
 
     /**
@@ -584,6 +590,26 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
             return t;
         }
+    }
+
+    /**
+     * @return All references in the form that are depended on by
+     * calculate/relevancy conditions.
+     */
+    public Enumeration<TreeReference> refWithTriggerDependencies() {
+        return triggerIndex.keys();
+    }
+
+    /**
+     * Get the triggerable conditions, like relevancy/calculate, that depend on
+     * the given reference.
+     *
+     * @param ref An absolute reference that is used in relevancy/calculate
+     *            expressions.
+     * @return All the triggerables that depend on the given reference.
+     */
+    public Vector<Triggerable> conditionsTriggeredByRef(TreeReference ref) {
+        return triggerIndex.get(ref);
     }
 
     /**

--- a/core/src/org/javarosa/core/model/FormDef.java
+++ b/core/src/org/javarosa/core/model/FormDef.java
@@ -111,8 +111,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     public Hashtable<TreeReference, Vector<Triggerable>> triggerIndex;
     private Hashtable<TreeReference, Condition> conditionRepeatTargetIndex;
-    // associates repeatable nodes with the Condition that determines their
-    // relevancy
+
+    /**
+     * Associates repeatable nodes with the Condition that determines their
+     * relevancy.
+     */
     public EvaluationContext exprEvalContext;
 
     private QuestionPreloader preloader = new QuestionPreloader();
@@ -868,13 +871,14 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * due to their update, and then dispatching all of the evaluations.
      *
      * @param tv        A vector of all of the trigerrables directly triggered by the
-     *                  value changed
+     *                  value changed. Will be mutated by this method.
      * @param anchorRef The reference to original value that was updated
      */
-    private void evaluateTriggerables(Vector tv, TreeReference anchorRef) {
-        //add all cascaded triggerables to queue
-
-        //Iterate through all of the currently known triggerables to be triggered
+    private void evaluateTriggerables(Vector<Triggerable> tv,
+                                      TreeReference anchorRef) {
+        // Update the list of triggerables that need to be evaluated.
+        // XXX PLM: tv changes in size throughout this loop.
+        //          Do we actually want to loop over the newly added elements?
         for (int i = 0; i < tv.size(); i++) {
             Triggerable t = (Triggerable)tv.elementAt(i);
             fillTriggeredElements(t, tv);

--- a/core/src/org/javarosa/core/model/FormDef.java
+++ b/core/src/org/javarosa/core/model/FormDef.java
@@ -593,6 +593,16 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     }
 
     /**
+     * Dependency-sorted enumerator for the triggerables present in the form.
+     *
+     * @return Enumerator of triggerables such that when an element X precedes
+     * Y then X doesn't have any references that are dependent on Y.
+     */
+    public Enumeration<Triggerable> getTriggerables() {
+        return triggerables.elements();
+    }
+
+    /**
      * @return All references in the form that are depended on by
      * calculate/relevancy conditions.
      */

--- a/core/src/org/javarosa/form/api/FormEntryModel.java
+++ b/core/src/org/javarosa/form/api/FormEntryModel.java
@@ -449,8 +449,8 @@ public class FormEntryModel {
      * the interface, it will merely use the xforms repeat hint to create new
      * nodes that are assumed to exist
      *
-     * @param The index to be evaluated as to whether the underlying model is
-     *            hinted to exist
+     * @param index To be evaluated as to whether the underlying model is
+     *              hinted to exist
      */
     public void createModelIfNecessary(FormIndex index) {
         if (index.isInForm()) {
@@ -475,7 +475,7 @@ public class FormEntryModel {
                                     getForm().createNewRepeat(index);
                                 } catch (InvalidReferenceException ire) {
                                     ire.printStackTrace();
-                                    throw new RuntimeException("Invalid Reference while creting new repeat!" + ire.getMessage());
+                                    throw new RuntimeException("Invalid Reference while creating new repeat!" + ire.getMessage());
                                 }
                             }
                         }

--- a/core/src/org/javarosa/xform/parse/XFormParser.java
+++ b/core/src/org/javarosa/xform/parse/XFormParser.java
@@ -2794,12 +2794,12 @@ public class XFormParser {
         Vector edges = new Vector();
 
         //build graph
-        for (Enumeration e = _f.triggerIndex.keys(); e.hasMoreElements(); ) {
+        for (Enumeration e = _f.refWithTriggerDependencies(); e.hasMoreElements(); ) {
             TreeReference trigger = (TreeReference)e.nextElement();
             if (!vertices.contains(trigger))
                 vertices.addElement(trigger);
 
-            Vector triggered = (Vector)_f.triggerIndex.get(trigger);
+            Vector<Triggerable> triggered = (Vector<Triggerable>)_f.conditionsTriggeredByRef(trigger);
             Vector targets = new Vector();
             for (int i = 0; i < triggered.size(); i++) {
                 Triggerable t = (Triggerable)triggered.elementAt(i);

--- a/core/src/org/javarosa/xpath/XPathConditional.java
+++ b/core/src/org/javarosa/xpath/XPathConditional.java
@@ -95,6 +95,16 @@ public class XPathConditional implements IConditionExpr {
         }
     }
 
+    /**
+     * Gather the references that affect the outcome of evaluating this
+     * conditional expression.
+     *
+     * @param originalContextRef context reference pointing to the nodeset
+     *                           reference; used for expanding 'current()'
+     * @return References of which this conditional expression depends on. Used
+     * for retriggering the expression's evaluation if any of these references
+     * value or relevancy calculations once.
+     */
     public Vector<TreeReference> getExprsTriggers(TreeReference originalContextRef) {
         Vector triggers = new Vector();
         getExprsTriggersAccumulator(expr, triggers, null, originalContextRef);

--- a/util/schema-gen/src/org/javarosa/xform/schema/FormOverview.java
+++ b/util/schema-gen/src/org/javarosa/xform/schema/FormOverview.java
@@ -20,6 +20,7 @@ import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
+import org.javarosa.core.model.condition.Triggerable;
 import org.javarosa.model.xform.XPathReference;
 import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
@@ -37,6 +38,8 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xform.util.XFormAnswerDataSerializer;
 import org.javarosa.xpath.XPathConditional;
+
+import java.util.Enumeration;
 
 public class FormOverview {
     public static String overview (FormDef f) {
@@ -197,24 +200,25 @@ public class FormOverview {
 
         IConditionExpr expr = null;
 
-        for (int i = 0; i < f.triggerables.size() && expr == null; i++) {
+        triggerLoop:
+        for (Enumeration<Triggerable> e = f.getTriggerables(); e.hasMoreElements();) {
+            Triggerable trig = e.nextElement();
             // Clayton Sims - Jun 1, 2009 : Not sure how legitimate this
             // cast is. It might work now, but break later.
             // Clayton Sims - Jun 24, 2009 : Yeah, that change broke things.
             // For now, we won't bother to print out anything that isn't
             // a condition.
-            if(f.triggerables.elementAt(i) instanceof Condition) {
-            Condition c = (Condition)f.triggerables.elementAt(i);
+            if (trig instanceof Condition) {
+                Condition c = (Condition)trig;
 
-            if (c.trueAction == action) {
-                for (int j = 0; j < c.targets.size() && expr == null; j++) {
-                    TreeReference target = (TreeReference)c.targets.elementAt(j);
-
-                    if (instanceNode == getInstanceNode(f.getInstance(), new XPathReference(target))) {
-                        expr = c.expr;
+                if (c.trueAction == action) {
+                    for (TreeReference target : c.targets) {
+                        if (instanceNode == getInstanceNode(f.getInstance(), new XPathReference(target))) {
+                            expr = c.expr;
+                            break triggerLoop;
+                        }
                     }
                 }
-            }
             }
         }
 


### PR DESCRIPTION
An old PR that I had to recreate because of merging issues:

Method level comments relating to triggers.
Made triggerIndex private and expose it through documented methods as a means to better understand its role.