### PR TITLE
Form instance loading doesn't handle leaf attributes (2.22)

### DIFF
--- a/core/src/org/javarosa/core/model/instance/TreeElement.java
+++ b/core/src/org/javarosa/core/model/instance/TreeElement.java
@@ -1010,13 +1010,13 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
                     }
                 }
             }
-            for (int i = 0; i < incoming.getAttributeCount(); i++) {
-                String name = incoming.getAttributeName(i);
-                String ns = incoming.getAttributeNamespace(i);
-                String value = incoming.getAttributeValue(i);
+        }
+        for (int i = 0; i < incoming.getAttributeCount(); i++) {
+            String name = incoming.getAttributeName(i);
+            String ns = incoming.getAttributeNamespace(i);
+            String value = incoming.getAttributeValue(i);
 
-                this.setAttribute(ns, name, value);
-            }
+            this.setAttribute(ns, name, value);
         }
     }
 


### PR DESCRIPTION
Minimal changeset version of https://github.com/dimagi/javarosa/pull/124 for 2.22

Form Instance loading doesn't correctly copy element attributes for leaf nodes.

Fix for http://manage.dimagi.com/default.asp?170392