### PR TITLE
Update test report timestamps so jenkins doesn't report test failures

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,3 +58,13 @@ task extractLibs(type: Copy) {
 }
 
 compileJava.dependsOn extractLibs
+
+task jenkinsTest{
+    inputs.files test.outputs.files
+    doLast{
+        def timestamp = System.currentTimeMillis()
+        test.getReports().getJunitXml().getDestination().eachFile { it.lastModified = timestamp }
+    }
+}
+
+check.dependsOn(jenkinsTest)


### PR DESCRIPTION
Jenkins was report test failures because the build ran but tests weren't updated.
This is just because gradle is smarter than jenkins.

The fix is to update the timestamps on the test results.