### PR TITLE
Create a build configuration for use in commcare/build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,9 +79,17 @@ jar {
     baseName = "javarosa-libraries"
 }
 
-task harnessJar(type: Jar) {
+configurations {
+  harnessOutput.extendsFrom (harnessCompile)
+}
+
+task harnessJar(type: Jar, dependsOn: harnessClasses) {
     baseName = "harness"
     from sourceSets.harness.output
+}
+
+artifacts {
+  harnessOutput harnessJar
 }
 
 task copyTestResources(type: Copy) {


### PR DESCRIPTION
In order to use the XFormPlayer in CommCare CLI tools, we need to expose the harness jar as a configuration here.