### PR TITLE
Force dummy storage to be intentional on prototype factory

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -679,7 +679,7 @@ public class TreeReference implements Externalizable {
         contextType = ExtUtil.readInt(in);
         int size = ExtUtil.readInt(in);
         for (int i = 0; i < size; ++i) {
-            TreeReferenceLevel level = (TreeReferenceLevel)ExtUtil.read(in, TreeReferenceLevel.class);
+            TreeReferenceLevel level = (TreeReferenceLevel)ExtUtil.read(in, TreeReferenceLevel.class, pf);
             this.add(level.intern());
         }
     }

--- a/core/src/main/java/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -95,7 +95,7 @@ public class TreeReferenceLevel implements Externalizable {
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         name = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         multiplicity = ExtUtil.readInt(in);
-        predicates = ExtUtil.nullIfEmpty((Vector<XPathExpression>)ExtUtil.read(in, new ExtWrapListPoly()));
+        predicates = ExtUtil.nullIfEmpty((Vector<XPathExpression>)ExtUtil.read(in, new ExtWrapListPoly(), pf));
     }
 
 

--- a/core/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
+++ b/core/src/main/java/org/javarosa/core/services/storage/util/DummyIndexedStorageUtility.java
@@ -41,10 +41,6 @@ public class DummyIndexedStorageUtility<T extends Persistable> implements IStora
     
     PrototypeFactory mFactory;
 
-    public DummyIndexedStorageUtility(Class<T> prototype) {
-        this(prototype, PrototypeManager.getDefault());
-    }
-
     public DummyIndexedStorageUtility(Class<T> prototype, PrototypeFactory factory) {
         meta = new Hashtable<String, Hashtable<Object, Vector<Integer>>>();
         data = new Hashtable<Integer, T>();


### PR DESCRIPTION
Migrated dummy storage to require an intentional prototype factory implementation, and fixed a few places where the PF wasn't being passed through objects

Fixes 
http://manage.dimagi.com/default.asp?179023#994114

X-Requested in commcare