### PR TITLE
fix delete repeat bug

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -357,6 +357,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             }
         }
 
+        this.getMainInstance().cleanCache();
+
         triggerTriggerables(deleteRef);
         return newIndex;
     }

--- a/core/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -320,4 +320,8 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
     public void setCacheHost(CacheHost cacheHost) {
         this.mCacheHost = cacheHost;
     }
+
+    public void cleanCache() {
+        referenceCache = new CacheTable<TreeReference, T>();
+    }
 }

--- a/core/src/main/java/org/javarosa/core/model/instance/DataInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/DataInstance.java
@@ -322,6 +322,6 @@ public abstract class DataInstance<T extends AbstractTreeElement<T>> implements 
     }
 
     public void cleanCache() {
-        referenceCache = new CacheTable<TreeReference, T>();
+        referenceCache.clear();
     }
 }

--- a/core/src/main/java/org/javarosa/core/util/CacheTable.java
+++ b/core/src/main/java/org/javarosa/core/util/CacheTable.java
@@ -123,4 +123,9 @@ public class CacheTable<T, K> {
             totalAdditions++;
         }
     }
+
+    public void clear(){
+        currentTable.clear();
+        caches.clear();
+    }
 }


### PR DESCRIPTION
@ctsims @benrudolph this fixes the issue by just wiping the cache when we delete a repeat. this happens rarely enough (not at all in ODK) that I think this is acceptable for now. Didn't want to spend too much time on this since it'll (hopefully) be addressed when we refactor the session into java 