### PR TITLE
Make StorageFullException take message in constructor

### DIFF
--- a/core/src/main/java/org/javarosa/core/services/storage/StorageFullException.java
+++ b/core/src/main/java/org/javarosa/core/services/storage/StorageFullException.java
@@ -5,5 +5,13 @@ package org.javarosa.core.services.storage;
  * space in the underlying device storage.
  */
 public class StorageFullException extends RuntimeException {
+    public StorageFullException() {
+        super();
+    }
+
+    public StorageFullException(String message) {
+        super(message);
+    }
+
 
 }


### PR DESCRIPTION
https://github.com/dimagi/javarosa/pull/149 tries to invoke a `StorageFullException` constructor that takes a `String` arg, which crashes when built on Jenkins, because that constructor doesn't exist. Add it.