### PR TITLE
Override hashCode whenever equals is overridden

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -725,7 +725,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                     //We can't make this reference generic before now or we'll lose the target information,
                     //so we'll be more inclusive than needed and see if any of our triggers are keyed on
                     //the predicate-less path of this ref
-                    Vector<Triggerable> triggered = (Vector<Triggerable>)triggerIndex.get(ref.hasPredicates() ? ref.removePredicates() : ref);
+                    TreeReference predicatelessRef = ref;
+                    if (ref.hasPredicates()) {
+                        predicatelessRef = ref.removePredicates();
+                    }
+                    Vector<Triggerable> triggered = (Vector<Triggerable>)triggerIndex.get(predicatelessRef);
 
                     if (triggered != null) {
                         //If so, walk all of these triggerables that we found
@@ -733,8 +737,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                             Triggerable u = (Triggerable)triggered.elementAt(k);
 
                             //And add them to the queue if they aren't there already
-                            if (!destination.contains(u))
+                            if (!destination.contains(u)) {
                                 destination.addElement(u);
+                            }
                         }
                     }
                 }

--- a/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -581,17 +581,13 @@ public class TreeReference implements Externalizable {
         return false;
     }
 
+    @Override
     public int hashCode() {
         if (hashCode != -1) {
             return hashCode;
         }
-        int hash = (DataUtil.integer(refLevel)).hashCode();
+        int hash = refLevel;
         for (int i = 0; i < size(); i++) {
-            //NOTE(ctsims): It looks like this is only using Integer to
-            //get the hashcode method, but that method
-            //is just returning the int value, I think, so
-            //this should potentially just be replaced by
-            //an int.
             Integer mult = DataUtil.integer(getMultiplicity(i));
             if (i == 0 && mult.intValue() == INDEX_UNBOUND)
                 mult = DataUtil.integer(0);

--- a/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -588,21 +588,22 @@ public class TreeReference implements Externalizable {
         }
         int hash = refLevel;
         for (int i = 0; i < size(); i++) {
-            Integer mult = DataUtil.integer(getMultiplicity(i));
-            if (i == 0 && mult.intValue() == INDEX_UNBOUND)
-                mult = DataUtil.integer(0);
+            int mult = getMultiplicity(i);
+            if (i == 0 && mult == INDEX_UNBOUND) {
+                mult = 0;
+            }
 
             hash ^= getName(i).hashCode();
-            hash ^= mult.hashCode();
+            hash ^= mult;
+
             Vector<XPathExpression> predicates = this.getPredicate(i);
-            if (predicates == null) {
-                continue;
-            }
-            int val = 0;
-            for (XPathExpression xpe : predicates) {
-                hash ^= val;
-                hash ^= xpe.hashCode();
-                ++val;
+            if (predicates != null) {
+                int val = 0;
+                for (XPathExpression xpe : predicates) {
+                    hash ^= val;
+                    hash ^= xpe.hashCode();
+                    ++val;
+                }
             }
         }
         hashCode = hash;

--- a/core/src/main/java/org/javarosa/core/model/instance/TreeReferenceLevel.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeReferenceLevel.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.javarosa.core.model.instance;
 
 import org.javarosa.core.util.ArrayUtilities;
@@ -39,6 +36,7 @@ public class TreeReferenceLevel implements Externalizable {
     }
 
     public TreeReferenceLevel() {
+        // for externalization
     }
 
 
@@ -91,20 +89,21 @@ public class TreeReferenceLevel implements Externalizable {
         return new TreeReferenceLevel(name, multiplicity, predicates).intern();
     }
 
-
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         name = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         multiplicity = ExtUtil.readInt(in);
         predicates = ExtUtil.nullIfEmpty((Vector<XPathExpression>)ExtUtil.read(in, new ExtWrapListPoly(), pf));
     }
 
-
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(name));
         ExtUtil.writeNumeric(out, multiplicity);
         ExtUtil.write(out, new ExtWrapListPoly(ExtUtil.emptyIfNull(predicates)));
     }
 
+    @Override
     public int hashCode() {
         int predPart = 0;
         if (predicates != null) {
@@ -123,6 +122,7 @@ public class TreeReferenceLevel implements Externalizable {
      * @param o an object to compare against this TreeReferenceLevel object.
      * @return Is object o a TreeReferenceLevel and has the same fields?
      */
+    @Override
     public boolean equals(Object o) {
         if (!(o instanceof TreeReferenceLevel)) {
             return false;
@@ -132,7 +132,7 @@ public class TreeReferenceLevel implements Externalizable {
         // multiplicity and names match-up
         if ((multiplicity != l.multiplicity) ||
                 (name == null && l.name != null) ||
-                (!name.equals(l.name))) {
+                (name != null && (!name.equals(l.name)))) {
             return false;
         }
 
@@ -141,8 +141,8 @@ public class TreeReferenceLevel implements Externalizable {
         }
 
         // predicates match-up
-        if ((predicates == null && l.predicates != null) ||
-                (l.predicates == null && predicates != null) ||
+        if (predicates == null ||
+                l.predicates == null ||
                 (predicates.size() != l.predicates.size())) {
             return false;
         }

--- a/core/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/core/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.javarosa.core.util;
 
 import java.util.Vector;
@@ -16,16 +13,27 @@ public class DataUtil {
 
     static UnionLambda unionLambda = new UnionLambda();
 
+    /**
+     * Get Integer object that corresponds to int argument from a
+     * pre-computed table, or build a new instance.
+     *
+     * @return Cached or new Integer instance that correpsonds to ivalue argument
+     */
     public static Integer integer(int ivalue) {
+        // lazily populate Integer cache
         if (iarray == null) {
             iarray = new Integer[high - low];
             for (int i = 0; i < iarray.length; ++i) {
                 iarray[i] = new Integer(i + low);
             }
         }
-        return ivalue < high && ivalue >= low ? iarray[ivalue + offset] : new Integer(ivalue);
-    }
 
+        if (ivalue < high && ivalue >= low) {
+            return iarray[ivalue + offset];
+        } else {
+            return new Integer(ivalue);
+        }
+    }
 
     public static <T> Vector<T> union(Vector<T> a, Vector<T> b) {
         return unionLambda.union(a, b);

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathArithExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathArithExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -43,6 +27,7 @@ public class XPathArithExpr extends XPathBinaryOpExpr {
         this.op = op;
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         double aval = XPathFuncExpr.toNumeric(a.eval(model, evalContext)).doubleValue();
         double bval = XPathFuncExpr.toNumeric(b.eval(model, evalContext)).doubleValue();
@@ -68,6 +53,7 @@ public class XPathArithExpr extends XPathBinaryOpExpr {
         return new Double(result);
     }
 
+    @Override
     public String toString() {
         String sOp = null;
 
@@ -92,6 +78,7 @@ public class XPathArithExpr extends XPathBinaryOpExpr {
         return super.toString(sOp);
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathArithExpr) {
             XPathArithExpr x = (XPathArithExpr)o;
@@ -101,16 +88,19 @@ public class XPathArithExpr extends XPathBinaryOpExpr {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         op = ExtUtil.readInt(in);
         super.readExternal(in, pf);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out, op);
         super.writeExternal(out);
     }
 
+    @Override
     public String toPrettyString() {
         String prettyA = a.toPrettyString();
         String prettyB = b.toPrettyString();

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathArithExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathArithExpr.java
@@ -17,14 +17,11 @@ public class XPathArithExpr extends XPathBinaryOpExpr {
     public static final int DIVIDE = 3;
     public static final int MODULO = 4;
 
-    public int op;
-
     public XPathArithExpr() {
     } //for deserialization
 
     public XPathArithExpr(int op, XPathExpression a, XPathExpression b) {
-        super(a, b);
-        this.op = op;
+        super(op, a, b);
     }
 
     @Override
@@ -76,28 +73,6 @@ public class XPathArithExpr extends XPathBinaryOpExpr {
         }
 
         return super.toString(sOp);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o instanceof XPathArithExpr) {
-            XPathArithExpr x = (XPathArithExpr)o;
-            return super.equals(o) && op == x.op;
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        op = ExtUtil.readInt(in);
-        super.readExternal(in, pf);
-    }
-
-    @Override
-    public void writeExternal(DataOutputStream out) throws IOException {
-        ExtUtil.writeNumeric(out, op);
-        super.writeExternal(out);
     }
 
     @Override

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
@@ -15,13 +15,15 @@ import java.util.Vector;
 
 public abstract class XPathBinaryOpExpr extends XPathOpExpr {
     public XPathExpression a, b;
+    public int op;
 
     public XPathBinaryOpExpr() {
     } //for deserialization of children
 
-    public XPathBinaryOpExpr(XPathExpression a, XPathExpression b) {
+    public XPathBinaryOpExpr(int op, XPathExpression a, XPathExpression b) {
         this.a = a;
         this.b = b;
+        this.op = op;
     }
 
     public String toString(String op) {
@@ -32,7 +34,7 @@ public abstract class XPathBinaryOpExpr extends XPathOpExpr {
     public boolean equals(Object o) {
         if (o instanceof XPathBinaryOpExpr) {
             XPathBinaryOpExpr x = (XPathBinaryOpExpr)o;
-            return a.equals(x.a) && b.equals(x.b);
+            return op == x.op && a.equals(x.a) && b.equals(x.b);
         } else {
             return false;
         }
@@ -40,12 +42,22 @@ public abstract class XPathBinaryOpExpr extends XPathOpExpr {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        op = ExtUtil.readInt(in);
+        readExpressions(in, pf);
+    }
+
+    protected void readExpressions(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         a = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
         b = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.writeNumeric(out, op);
+        writeExpressions(out);
+    }
+
+    protected void writeExpressions(DataOutputStream out) throws IOException {
         ExtUtil.write(out, new ExtWrapTagged(a));
         ExtUtil.write(out, new ExtWrapTagged(b));
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
@@ -41,6 +41,11 @@ public abstract class XPathBinaryOpExpr extends XPathOpExpr {
     }
 
     @Override
+    public int hashCode() {
+        return op ^ a.hashCode() ^ b.hashCode();
+    }
+
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         op = ExtUtil.readInt(in);
         readExpressions(in, pf);

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -44,6 +28,7 @@ public abstract class XPathBinaryOpExpr extends XPathOpExpr {
         return "{binop-expr:" + op + "," + a.toString() + "," + b.toString() + "}";
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathBinaryOpExpr) {
             XPathBinaryOpExpr x = (XPathBinaryOpExpr)o;
@@ -53,16 +38,19 @@ public abstract class XPathBinaryOpExpr extends XPathOpExpr {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         a = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
         b = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, new ExtWrapTagged(a));
         ExtUtil.write(out, new ExtWrapTagged(b));
     }
 
+    @Override
     public Object pivot(DataInstance model, EvaluationContext evalContext, Vector<Object> pivots, Object sentinal) throws UnpivotableExpressionException {
         //Pivot both args
         Object aval = a.pivot(model, evalContext, pivots, sentinal);

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathBoolExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathBoolExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -40,6 +24,7 @@ public class XPathBoolExpr extends XPathBinaryOpExpr {
         this.op = op;
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         boolean aval = XPathFuncExpr.toBoolean(a.eval(model, evalContext)).booleanValue();
 
@@ -62,6 +47,7 @@ public class XPathBoolExpr extends XPathBinaryOpExpr {
         return new Boolean(result);
     }
 
+    @Override
     public String toString() {
         String sOp = null;
 
@@ -77,6 +63,7 @@ public class XPathBoolExpr extends XPathBinaryOpExpr {
         return super.toString(sOp);
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathBoolExpr) {
             XPathBoolExpr x = (XPathBoolExpr)o;
@@ -86,16 +73,19 @@ public class XPathBoolExpr extends XPathBinaryOpExpr {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         op = ExtUtil.readInt(in);
         super.readExternal(in, pf);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out, op);
         super.writeExternal(out);
     }
 
+    @Override
     public String toPrettyString() {
         String prettyA = a.toPrettyString();
         String prettyB = b.toPrettyString();

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathBoolExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathBoolExpr.java
@@ -14,14 +14,11 @@ public class XPathBoolExpr extends XPathBinaryOpExpr {
     public static final int AND = 0;
     public static final int OR = 1;
 
-    public int op;
-
     public XPathBoolExpr() {
     } //for deserialization
 
     public XPathBoolExpr(int op, XPathExpression a, XPathExpression b) {
-        super(a, b);
-        this.op = op;
+        super(op, a, b);
     }
 
     @Override
@@ -61,28 +58,6 @@ public class XPathBoolExpr extends XPathBinaryOpExpr {
         }
 
         return super.toString(sOp);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o instanceof XPathBoolExpr) {
-            XPathBoolExpr x = (XPathBoolExpr)o;
-            return super.equals(o) && op == x.op;
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        op = ExtUtil.readInt(in);
-        super.readExternal(in, pf);
-    }
-
-    @Override
-    public void writeExternal(DataOutputStream out) throws IOException {
-        ExtUtil.writeNumeric(out, op);
-        super.writeExternal(out);
     }
 
     @Override

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathCmpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathCmpExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -48,6 +32,7 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
         this.op = op;
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         Object aval = a.eval(model, evalContext);
         Object bval = b.eval(model, evalContext);
@@ -78,6 +63,7 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
         return new Boolean(result);
     }
 
+    @Override
     public String toString() {
         String sOp = null;
 
@@ -99,6 +85,7 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
         return super.toString(sOp);
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathCmpExpr) {
             XPathCmpExpr x = (XPathCmpExpr)o;
@@ -108,17 +95,20 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         op = ExtUtil.readInt(in);
         super.readExternal(in, pf);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out, op);
         super.writeExternal(out);
     }
 
 
+    @Override
     public Object pivot(DataInstance model, EvaluationContext evalContext, Vector<Object> pivots, Object sentinal) throws UnpivotableExpressionException {
         Object aval = a.pivot(model, evalContext, pivots, sentinal);
         Object bval = b.pivot(model, evalContext, pivots, sentinal);
@@ -180,6 +170,7 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
         return false;
     }
 
+    @Override
     public String toPrettyString() {
         String prettyA = a.toPrettyString();
         String prettyB = b.toPrettyString();

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathCmpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathCmpExpr.java
@@ -22,14 +22,11 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
     public static final int LTE = 2;
     public static final int GTE = 3;
 
-    public int op;
-
     public XPathCmpExpr() {
     } //for deserialization
 
     public XPathCmpExpr(int op, XPathExpression a, XPathExpression b) {
-        super(a, b);
-        this.op = op;
+        super(op, a, b);
     }
 
     @Override
@@ -84,29 +81,6 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
 
         return super.toString(sOp);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o instanceof XPathCmpExpr) {
-            XPathCmpExpr x = (XPathCmpExpr)o;
-            return super.equals(o) && op == x.op;
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        op = ExtUtil.readInt(in);
-        super.readExternal(in, pf);
-    }
-
-    @Override
-    public void writeExternal(DataOutputStream out) throws IOException {
-        ExtUtil.writeNumeric(out, op);
-        super.writeExternal(out);
-    }
-
 
     @Override
     public Object pivot(DataInstance model, EvaluationContext evalContext, Vector<Object> pivots, Object sentinal) throws UnpivotableExpressionException {

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathEqExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathEqExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -37,6 +21,7 @@ public class XPathEqExpr extends XPathBinaryOpExpr {
         this.equal = equal;
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         Object aval = XPathFuncExpr.unpack(a.eval(model, evalContext));
         Object bval = XPathFuncExpr.unpack(b.eval(model, evalContext));
@@ -45,10 +30,12 @@ public class XPathEqExpr extends XPathBinaryOpExpr {
         return new Boolean(equal ? eq : !eq);
     }
 
+    @Override
     public String toString() {
         return super.toString(equal ? "==" : "!=");
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathEqExpr) {
             XPathEqExpr x = (XPathEqExpr)o;
@@ -58,11 +45,13 @@ public class XPathEqExpr extends XPathBinaryOpExpr {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         equal = ExtUtil.readBool(in);
         super.readExternal(in, pf);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeBool(out, equal);
         super.writeExternal(out);
@@ -107,6 +96,7 @@ public class XPathEqExpr extends XPathBinaryOpExpr {
         return eq;
     }
 
+    @Override
     public String toPrettyString() {
         String prettyA = a.toPrettyString();
         String prettyB = b.toPrettyString();

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
@@ -270,10 +270,13 @@ public abstract class XPathExpression implements Externalizable {
         indent -= 1;
     }
 
+    // Make sure hashCode and equals are implemented by child classes.
+    // If you override one, it is best practice to also override the other.
     @Override
-    public int hashCode() {
-        return this.toString().hashCode();
-    }
+    public abstract int hashCode();
+
+    @Override
+    public abstract boolean equals(Object o);
 
     /**
      * @return a best-effort for the cannonical representation

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
@@ -162,7 +162,7 @@ public abstract class XPathExpression implements Externalizable {
             printStr("}}");
         } else if (o instanceof XPathEqExpr) {
             XPathEqExpr x = (XPathEqExpr)o;
-            String op = x.equal ? "eq" : "neq";
+            String op = x.op == XPathEqExpr.EQ ? "eq" : "neq";
             printStr(op + " {{");
             print(x.a);
             printStr(" } {");

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathExpression.java
@@ -270,6 +270,7 @@ public abstract class XPathExpression implements Externalizable {
         indent -= 1;
     }
 
+    @Override
     public int hashCode() {
         return this.toString().hashCode();
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFilterExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFilterExpr.java
@@ -15,6 +15,10 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Vector;
 
+/**
+ * This construct, whose syntax is of the form '(filter-expr pred1 pred2 ...)',
+ * is currently unsupported by JavaRosa
+ */
 public class XPathFilterExpr extends XPathExpression {
     public XPathExpression x;
     public XPathExpression[] predicates;
@@ -58,6 +62,15 @@ public class XPathFilterExpr extends XPathExpression {
         } else {
             return false;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        int predHash = 0;
+        for (XPathExpression pred : predicates) {
+            predHash ^= pred.hashCode();
+        }
+        return x.hashCode() ^ predHash;
     }
 
     @Override

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFilterExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFilterExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -43,10 +27,12 @@ public class XPathFilterExpr extends XPathExpression {
         this.predicates = predicates;
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         throw new XPathUnsupportedException("filter expression");
     }
 
+    @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
 
@@ -63,6 +49,7 @@ public class XPathFilterExpr extends XPathExpression {
         return sb.toString();
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathFilterExpr) {
             XPathFilterExpr fe = (XPathFilterExpr)o;
@@ -73,6 +60,7 @@ public class XPathFilterExpr extends XPathExpression {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         x = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
         Vector v = (Vector)ExtUtil.read(in, new ExtWrapListPoly(), pf);
@@ -82,19 +70,23 @@ public class XPathFilterExpr extends XPathExpression {
             predicates[i] = (XPathExpression)v.elementAt(i);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         Vector v = new Vector();
-        for (int i = 0; i < predicates.length; i++)
+        for (int i = 0; i < predicates.length; i++) {
             v.addElement(predicates[i]);
+        }
 
         ExtUtil.write(out, new ExtWrapTagged(x));
         ExtUtil.write(out, new ExtWrapListPoly(v));
     }
 
+    @Override
     public Object pivot(DataInstance model, EvaluationContext evalContext, Vector<Object> pivots, Object sentinal) throws UnpivotableExpressionException {
         throw new UnpivotableExpressionException();
     }
 
+    @Override
     public String toPrettyString() {
         return "Unsupported Predicate";
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -63,6 +63,7 @@ public class XPathFuncExpr extends XPathExpression {
         this.args = args;
     }
 
+    @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
 
@@ -79,6 +80,7 @@ public class XPathFuncExpr extends XPathExpression {
         return sb.toString();
     }
 
+    @Override
     public String toPrettyString() {
         StringBuffer sb = new StringBuffer();
         sb.append(id.toString() + "(");
@@ -92,6 +94,7 @@ public class XPathFuncExpr extends XPathExpression {
         return sb.toString();
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathFuncExpr) {
             XPathFuncExpr x = (XPathFuncExpr)o;
@@ -111,6 +114,7 @@ public class XPathFuncExpr extends XPathExpression {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         id = (XPathQName)ExtUtil.read(in, XPathQName.class);
         Vector v = (Vector)ExtUtil.read(in, new ExtWrapListPoly(), pf);
@@ -120,6 +124,7 @@ public class XPathFuncExpr extends XPathExpression {
             args[i] = (XPathExpression)v.elementAt(i);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         Vector v = new Vector();
         for (int i = 0; i < args.length; i++)
@@ -139,6 +144,7 @@ public class XPathFuncExpr extends XPathExpression {
      * handler. For built-in functions, the number of arguments must match; for custom functions,
      * the supplied arguments must match one of the function prototypes defined by the handler.
      */
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         String name = id.toString();
         Object[] argVals = new Object[args.length];
@@ -1106,9 +1112,7 @@ public class XPathFuncExpr extends XPathExpression {
         }
     }
 
-    /**
-     *
-     */
+    @Override
     public Object pivot(DataInstance model, EvaluationContext evalContext, Vector<Object> pivots, Object sentinal) throws UnpivotableExpressionException {
         String name = id.toString();
 

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -115,6 +115,15 @@ public class XPathFuncExpr extends XPathExpression {
     }
 
     @Override
+    public int hashCode() {
+        int argsHash = 0;
+        for (XPathExpression arg : args) {
+            argsHash ^= arg.hashCode();
+        }
+        return id.hashCode() ^ argsHash;
+    }
+
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         id = (XPathQName)ExtUtil.read(in, XPathQName.class);
         Vector v = (Vector)ExtUtil.read(in, new ExtWrapListPoly(), pf);

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathNumNegExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathNumNegExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -27,21 +11,25 @@ import java.io.IOException;
 
 public class XPathNumNegExpr extends XPathUnaryOpExpr {
     public XPathNumNegExpr() {
-    } //for deserialization
+        // for deserialization
+    }
 
     public XPathNumNegExpr(XPathExpression a) {
         super(a);
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         double aval = XPathFuncExpr.toNumeric(a.eval(model, evalContext)).doubleValue();
         return new Double(-aval);
     }
 
+    @Override
     public String toString() {
         return "{unop-expr:num-neg," + a.toString() + "}";
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathNumNegExpr) {
             return super.equals(o);
@@ -50,14 +38,17 @@ public class XPathNumNegExpr extends XPathUnaryOpExpr {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
     }
 
+    @Override
     public String toPrettyString() {
         return "-" + a.toPrettyString();
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -36,14 +20,17 @@ public class XPathNumericLiteral extends XPathExpression {
         this.d = d.doubleValue();
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         return new Double(d);
     }
 
+    @Override
     public String toString() {
         return "{num:" + Double.toString(d) + "}";
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathNumericLiteral) {
             XPathNumericLiteral x = (XPathNumericLiteral)o;
@@ -53,6 +40,7 @@ public class XPathNumericLiteral extends XPathExpression {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         if (in.readByte() == (byte)0x00) {
             d = ExtUtil.readNumeric(in);
@@ -61,6 +49,7 @@ public class XPathNumericLiteral extends XPathExpression {
         }
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         if (d == (int)d) {
             out.writeByte(0x00);
@@ -71,6 +60,7 @@ public class XPathNumericLiteral extends XPathExpression {
         }
     }
 
+    @Override
     public String toPrettyString() {
         return Double.toString(d);
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java
@@ -41,6 +41,11 @@ public class XPathNumericLiteral extends XPathExpression {
     }
 
     @Override
+    public int hashCode() {
+        return Long.valueOf(Double.doubleToLongBits(d)).hashCode();
+    }
+
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         if (in.readByte() == (byte)0x00) {
             d = ExtUtil.readNumeric(in);

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathOpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathOpExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 public abstract class XPathOpExpr extends XPathExpression {

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -168,6 +168,7 @@ public class XPathPathExpr extends XPathExpression {
         return ref;
     }
 
+    @Override
     public XPathNodeset evalRaw(DataInstance m, EvaluationContext ec) {
         TreeReference genericRef = getReference();
 
@@ -265,6 +266,7 @@ public class XPathPathExpr extends XPathExpression {
         }
     }
 
+    @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
 
@@ -291,6 +293,7 @@ public class XPathPathExpr extends XPathExpression {
         return sb.toString();
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathPathExpr) {
             XPathPathExpr x = (XPathPathExpr)o;
@@ -352,6 +355,7 @@ public class XPathPathExpr extends XPathExpression {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         init_context = ExtUtil.readInt(in);
         if (init_context == INIT_CONTEXT_EXPR) {
@@ -364,6 +368,7 @@ public class XPathPathExpr extends XPathExpression {
             steps[i] = ((XPathStep)v.elementAt(i)).intern();
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out, init_context);
         if (init_context == INIT_CONTEXT_EXPR) {
@@ -371,8 +376,9 @@ public class XPathPathExpr extends XPathExpression {
         }
 
         Vector v = new Vector();
-        for (int i = 0; i < steps.length; i++)
+        for (int i = 0; i < steps.length; i++) {
             v.addElement(steps[i]);
+        }
         ExtUtil.write(out, new ExtWrapList(v));
     }
 
@@ -406,6 +412,7 @@ public class XPathPathExpr extends XPathExpression {
         }
     }
 
+    @Override
     public String toPrettyString() {
         return getReference(true).toString(true);
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -309,6 +309,19 @@ public class XPathPathExpr extends XPathExpression {
         }
     }
 
+    @Override
+    public int hashCode() {
+        int stepsHash = 0;
+        for (XPathStep step : steps) {
+            stepsHash ^= step.hashCode();
+        }
+
+        if (init_context == INIT_CONTEXT_EXPR) {
+            return init_context ^ stepsHash ^ filtExpr.hashCode();
+        }
+        return init_context ^ stepsHash;
+    }
+
     /**
      * Warning: this method has somewhat unclear semantics.
      *

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathQName.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathQName.java
@@ -47,6 +47,7 @@ public class XPathQName implements Externalizable {
         init(namespace, name);
     }
 
+    @Override
     public int hashCode() {
         return hashCode;
     }
@@ -63,13 +64,15 @@ public class XPathQName implements Externalizable {
     }
 
     private void cacheCode() {
-        hashCode = name.hashCode() | (namespace == null ? 0 : namespace.hashCode());
+        hashCode = name.hashCode() ^ (namespace == null ? 0 : namespace.hashCode());
     }
 
+    @Override
     public String toString() {
         return (namespace == null ? name : namespace + ":" + name);
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathQName) {
             XPathQName x = (XPathQName)o;
@@ -82,12 +85,14 @@ public class XPathQName implements Externalizable {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         namespace = (String)ExtUtil.read(in, new ExtWrapNullable(String.class));
         name = ExtUtil.readString(in);
         cacheCode();
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, new ExtWrapNullable(namespace));
         ExtUtil.writeString(out, name);

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathStep.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathStep.java
@@ -82,6 +82,7 @@ public class XPathStep implements Externalizable {
         this.namespace = namespace;
     }
 
+    @Override
     public String toString() {
         StringBuffer sb = new StringBuffer();
 
@@ -158,6 +159,7 @@ public class XPathStep implements Externalizable {
         }
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathStep) {
             XPathStep x = (XPathStep)o;
@@ -243,6 +245,7 @@ public class XPathStep implements Externalizable {
         }
     }
 
+    @Override
     public int hashCode() {
         int code = this.axis ^ this.test ^ (this.name == null ? 0 : this.name.hashCode()) ^ (this.literal == null ? 0 : this.literal.hashCode()) ^ (this.namespace == null ? 0 : this.namespace.hashCode());
         for (XPathExpression xpe : predicates) {
@@ -251,6 +254,7 @@ public class XPathStep implements Externalizable {
         return code;
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         axis = ExtUtil.readInt(in);
         test = ExtUtil.readInt(in);
@@ -273,6 +277,7 @@ public class XPathStep implements Externalizable {
             predicates[i] = (XPathExpression)v.elementAt(i);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeNumeric(out, axis);
         ExtUtil.writeNumeric(out, test);

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathStringLiteral.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathStringLiteral.java
@@ -41,6 +41,11 @@ public class XPathStringLiteral extends XPathExpression {
     }
 
     @Override
+    public int hashCode() {
+        return s.hashCode();
+    }
+
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         s = ExtUtil.readString(in);
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathStringLiteral.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathStringLiteral.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -36,14 +20,17 @@ public class XPathStringLiteral extends XPathExpression {
         this.s = s;
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         return s;
     }
 
+    @Override
     public String toString() {
         return "{str:\'" + s + "\'}"; //TODO: s needs to be escaped (' -> \'; \ -> \\)
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathStringLiteral) {
             XPathStringLiteral x = (XPathStringLiteral)o;
@@ -53,14 +40,17 @@ public class XPathStringLiteral extends XPathExpression {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         s = ExtUtil.readString(in);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, s);
     }
 
+    @Override
     public String toPrettyString() {
         return "'" + s + "'";
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathUnaryOpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathUnaryOpExpr.java
@@ -13,12 +13,14 @@ public abstract class XPathUnaryOpExpr extends XPathOpExpr {
     public XPathExpression a;
 
     public XPathUnaryOpExpr() {
-    } //for deserialization of children
+         // for deserialization of children
+    }
 
     public XPathUnaryOpExpr(XPathExpression a) {
         this.a = a;
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathUnaryOpExpr) {
             XPathUnaryOpExpr x = (XPathUnaryOpExpr)o;
@@ -28,10 +30,17 @@ public abstract class XPathUnaryOpExpr extends XPathOpExpr {
         }
     }
 
+    @Override
+    public int hashCode() {
+        return a.hashCode();
+    }
+
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         a = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, new ExtWrapTagged(a));
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
@@ -30,12 +30,13 @@ public class XPathUnionExpr extends XPathBinaryOpExpr {
 
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        super.readExternal(in, pf);
+        readExpressions(in, pf);
+        op = -1;
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
-        super.writeExternal(out);
+        writeExpressions(out);
     }
 
     @Override

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -34,14 +18,17 @@ public class XPathUnionExpr extends XPathBinaryOpExpr {
         super(a, b);
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         throw new XPathUnsupportedException("nodeset union operation");
     }
 
+    @Override
     public String toString() {
         return super.toString("union");
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathUnionExpr) {
             return super.equals(o);
@@ -50,14 +37,17 @@ public class XPathUnionExpr extends XPathBinaryOpExpr {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
     }
 
+    @Override
     public String toPrettyString() {
         return "unsupported union operation";
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
@@ -15,7 +15,7 @@ public class XPathUnionExpr extends XPathBinaryOpExpr {
     } //for deserialization
 
     public XPathUnionExpr(XPathExpression a, XPathExpression b) {
-        super(a, b);
+        super(-1, a, b);
     }
 
     @Override
@@ -26,15 +26,6 @@ public class XPathUnionExpr extends XPathBinaryOpExpr {
     @Override
     public String toString() {
         return super.toString("union");
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o instanceof XPathUnionExpr) {
-            return super.equals(o);
-        } else {
-            return false;
-        }
     }
 
     @Override

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathVariableReference.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathVariableReference.java
@@ -41,6 +41,11 @@ public class XPathVariableReference extends XPathExpression {
     }
 
     @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         id = (XPathQName)ExtUtil.read(in, XPathQName.class);
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathVariableReference.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathVariableReference.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.expr;
 
 import org.javarosa.core.model.condition.EvaluationContext;
@@ -36,14 +20,17 @@ public class XPathVariableReference extends XPathExpression {
         this.id = id;
     }
 
+    @Override
     public Object evalRaw(DataInstance model, EvaluationContext evalContext) {
         return evalContext.getVariable(id.toString());
     }
 
+    @Override
     public String toString() {
         return "{var:" + id.toString() + "}";
     }
 
+    @Override
     public boolean equals(Object o) {
         if (o instanceof XPathVariableReference) {
             XPathVariableReference x = (XPathVariableReference)o;
@@ -53,14 +40,17 @@ public class XPathVariableReference extends XPathExpression {
         }
     }
 
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         id = (XPathQName)ExtUtil.read(in, XPathQName.class);
     }
 
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.write(out, id);
     }
 
+    @Override
     public String toPrettyString() {
         return "$" + id.toString();
     }

--- a/core/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeBinaryOp.java
+++ b/core/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeBinaryOp.java
@@ -71,9 +71,9 @@ public class ASTNodeBinaryOp extends ASTNode {
             case Token.AND:
                 return new XPathBoolExpr(XPathBoolExpr.AND, a, b);
             case Token.EQ:
-                return new XPathEqExpr(true, a, b);
+                return new XPathEqExpr(XPathEqExpr.EQ, a, b);
             case Token.NEQ:
-                return new XPathEqExpr(false, a, b);
+                return new XPathEqExpr(XPathEqExpr.NEQ, a, b);
             case Token.LT:
                 return new XPathCmpExpr(XPathCmpExpr.LT, a, b);
             case Token.LTE:

--- a/core/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFilterExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/parser/ast/ASTNodeFilterExpr.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath.parser.ast;
 
 import org.javarosa.xpath.expr.XPathExpression;
@@ -31,6 +15,7 @@ public class ASTNodeFilterExpr extends ASTNode {
         predicates = new Vector();
     }
 
+    @Override
     public Vector getChildren() {
         Vector v = new Vector();
         v.addElement(expr);
@@ -39,6 +24,7 @@ public class ASTNodeFilterExpr extends ASTNode {
         return v;
     }
 
+    @Override
     public XPathExpression build() throws XPathSyntaxException {
         XPathExpression[] preds = new XPathExpression[predicates.size()];
         for (int i = 0; i < preds.length; i++)


### PR DESCRIPTION
Due to the interdependence of the `hashCode` and `equals` contracts (see [hashCode docs](https://docs.oracle.com/javase/1.5.0/docs/api/java/lang/Object.html#hashCode%28%29)), whenever one is overridden, it is pretty important to override the other.

For all the implementers of `XPathExpression` this was being done, but in a very round about way via the `toString` implementation. It is important that the fields used to calculate `equals` are also used in determining the result of `hashCode` so the distance between the two implementations could lead to bugs.

This PR enforces that all implementers of `XPathExpression` explicitly override both `hashCode` and `equals`.

In addition, I removed some duplicate code between the implementations of `XPathBinaryOpExpr` by consolidating the `op` field from all of the implementers into `XPathBinaryOpExpr`. Note that I took care to not change the behaviour of `read/writeExternal`, even though they have been refactored.