### PR TITLE
Don't use Long.valueOf

### DIFF
--- a/core/src/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java
@@ -42,7 +42,7 @@ public class XPathNumericLiteral extends XPathExpression {
 
     @Override
     public int hashCode() {
-        return Long.valueOf(Double.doubleToLongBits(d)).hashCode();
+        return (new Long(Double.doubleToLongBits(d))).hashCode();
     }
 
     @Override


### PR DESCRIPTION
Fix for build error introduced by https://github.com/dimagi/javarosa/pull/168
```
   [javac] Internal J2ME Polish class: <http://jenkins.dimagi.com/job/commcare-mobile/ws/application/build/real/Generic/CustomKeys/none/source/main/java/org/javarosa/xpath/expr/XPathNumericLiteral.java>:45: error: cannot find symbol
    [javac]         return Long.valueOf(Double.doubleToLongBits(d)).hashCode();
    [javac]                    ^
    [javac]   symbol:   method valueOf(long)
    [javac]   location: class Long
```