### PR TITLE
Expose test source files to external projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ jar {
 
 configurations {
   harness
-  spi
+  testsAsJar
 }
 
 task harnessJar(type: Jar, dependsOn: harnessClasses) {
@@ -101,6 +101,8 @@ task harnessJar(type: Jar, dependsOn: harnessClasses) {
     }
 }
 
+// used to provide the test source files to external projects, such as odk,
+// which might want to import classes
 task testsrcJar(type: Jar, dependsOn: testClasses) {
     classifier = 'tests'
     from files(sourceSets.test.output.classesDir)
@@ -108,7 +110,7 @@ task testsrcJar(type: Jar, dependsOn: testClasses) {
 
 artifacts {
   harness harnessJar
-  spi testsrcJar
+  testsAsJar testsrcJar
 }
 
 task copyTestResources(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ jar {
 
 configurations {
   harness
+  spi
 }
 
 task harnessJar(type: Jar, dependsOn: harnessClasses) {
@@ -98,11 +99,16 @@ task harnessJar(type: Jar, dependsOn: harnessClasses) {
     manifest {
         attributes 'Main-Class': 'org.javarosa.engine.Harness'
     }
-    
+}
+
+task testsrcJar(type: Jar, dependsOn: testClasses) {
+    classifier = 'tests'
+    from files(sourceSets.test.output.classesDir)
 }
 
 artifacts {
   harness harnessJar
+  spi testsrcJar
 }
 
 task copyTestResources(type: Copy) {


### PR DESCRIPTION
Useful to enable odk to import classes defined in the testing section of javarosa.
Cross-requested https://github.com/dimagi/commcare-odk/pull/671