### PR TITLE
Fix for Instance Caching

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java
@@ -34,6 +34,7 @@ public class ExternalDataInstance extends DataInstance {
         this.reference = instance.getReference();
         this.base = instance.getBase();
         this.root = instance.getRoot();
+        this.mCacheHost = instance.getCacheHost();
     }
 
 
@@ -74,5 +75,6 @@ public class ExternalDataInstance extends DataInstance {
         root = initializer.generateRoot(this);
         base.setChild(root);
         return initializer.getSpecializedExternalDataInstance(this);
+
     }
 }


### PR DESCRIPTION
New DataInstance models weren't copying over the cache host in the copy constructor so Cache and Index behavior had broken. Fixes a bug for TDH and m2mdemo