### PR TITLE
misc logging refactor & raise file not found

### DIFF
--- a/core/src/main/java/org/javarosa/core/log/FlatLogSerializer.java
+++ b/core/src/main/java/org/javarosa/core/log/FlatLogSerializer.java
@@ -1,46 +1,20 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
-/**
- *
- */
 package org.javarosa.core.log;
 
 /**
  * @author Clayton Sims
- * @date Apr 10, 2009
  */
 public class FlatLogSerializer implements IFullLogSerializer<String> {
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.log.ILogSerializer#serializeLog(org.javarosa.core.log.IncidentLog)
-     */
-    private String serializeLog(LogEntry log) {
-        return "[" + log.getType() + "] " + log.getTime().toString() + ": " + log.message + "\n";
-    }
-
-    /* (non-Javadoc)
-     * @see org.javarosa.core.log.ILogSerializer#serializeLogs(org.javarosa.core.log.IncidentLog[])
-     */
+    @Override
     public String serializeLogs(LogEntry[] logs) {
-        String log = "";
-        for (int i = 0; i < logs.length; ++i) {
-            log += this.serializeLog(logs[i]);
+        StringBuilder stringBuilder = new StringBuilder("");
+        for (LogEntry logEntry : logs) {
+            stringBuilder.append(serializeLog(logEntry));
         }
-        return log;
+        return stringBuilder.toString();
     }
 
+    private String serializeLog(LogEntry log) {
+        return "[" + log.getType() + "] " + log.getTime().toString() + ": " + log.getMessage() + "\n";
+    }
 }

--- a/core/src/main/java/org/javarosa/core/log/IFullLogSerializer.java
+++ b/core/src/main/java/org/javarosa/core/log/IFullLogSerializer.java
@@ -2,8 +2,7 @@ package org.javarosa.core.log;
 
 /**
  * @author Clayton Sims
- * @date Apr 10, 2009
  */
 public interface IFullLogSerializer<T> {
-    public T serializeLogs(LogEntry[] logs);
+    T serializeLogs(LogEntry[] logs);
 }

--- a/core/src/main/java/org/javarosa/core/log/LogEntry.java
+++ b/core/src/main/java/org/javarosa/core/log/LogEntry.java
@@ -12,26 +12,16 @@ import java.util.Date;
 
 /**
  * @author Clayton Sims
- * @date Apr 10, 2009
  */
 public class LogEntry implements Externalizable {
-
     public static final String STORAGE_KEY = "LOG";
 
-    public static String LOG_TYPE_APPLICATION = "APP";
-    public static String LOG_TYPE_ACTIVITY = "ACTIVITY";
+    private Date time;
+    private String type;
+    private String message;
 
-    Date time;
-
-    String type;
-
-    String message;
-
-    /**
-     * NOTE: For serialization purposes only
-     */
     public LogEntry() {
-
+        // for externalization
     }
 
     public LogEntry(String type, String message, Date time) {
@@ -40,30 +30,19 @@ public class LogEntry implements Externalizable {
         this.message = message;
     }
 
-    /**
-     * @return the time
-     */
     public Date getTime() {
         return time;
     }
 
-    /**
-     * @return the type
-     */
     public String getType() {
         return type;
     }
 
-    /**
-     * @return the message
-     */
     public String getMessage() {
         return message;
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {
         time = ExtUtil.readDate(in);
@@ -71,9 +50,7 @@ public class LogEntry implements Externalizable {
         message = ExtUtil.readString(in);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.util.externalizable.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeDate(out, time);
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(type));

--- a/core/src/main/java/org/javarosa/core/log/StreamLogSerializer.java
+++ b/core/src/main/java/org/javarosa/core/log/StreamLogSerializer.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package org.javarosa.core.log;
 
 import org.javarosa.core.util.SortedIntSet;

--- a/core/src/main/java/org/javarosa/core/reference/ResourceReference.java
+++ b/core/src/main/java/org/javarosa/core/reference/ResourceReference.java
@@ -1,5 +1,6 @@
 package org.javarosa.core.reference;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -48,6 +49,9 @@ public class ResourceReference implements Reference {
      */
     public InputStream getStream() throws IOException {
         InputStream is = System.class.getResourceAsStream(URI);
+        if (is == null) {
+            throw new FileNotFoundException();
+        }
         return is;
     }
 


### PR DESCRIPTION
 - Random linting in logging files.
 - Make `ResourceReference.getStream` raise a FileNotFoundException to enable returning a `MissingResource` status when an app install/update tries to install an app that is missing a multimedia file.
