### PR TITLE
Revert change that makes externalizable class method abstract

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/Action.java
+++ b/core/src/main/java/org/javarosa/core/model/Action.java
@@ -34,7 +34,8 @@ public abstract class Action implements Externalizable {
      * WITHIN the context provided, if one is provided. This will
      * need to get changed possibly for future action types.
      */
-    public abstract void processAction(FormDef model, TreeReference context);
+    public void processAction(FormDef model, TreeReference context) {
+    }
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         name = ExtUtil.readString(in);

--- a/core/src/main/java/org/javarosa/core/model/actions/SetValueAction.java
+++ b/core/src/main/java/org/javarosa/core/model/actions/SetValueAction.java
@@ -46,8 +46,8 @@ public class SetValueAction extends Action {
         this.explicitValue = explicitValue;
     }
 
+    @Override
     public void processAction(FormDef model, TreeReference contextRef) {
-
         //Qualify the reference if necessary
         TreeReference qualifiedReference = contextRef == null ? target : target.contextualize(contextRef);
 


### PR DESCRIPTION
This was breaking J2ME builds because it requires some sort of polymorphic externalization magic.