### PR TITLE
Dynamic refreshing of question content in question lists

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -92,6 +92,18 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         return root.getChildAt(0);
     }
 
+    public void printFormDOM() {
+        printFormDOM(this.root);
+    }
+
+    private void printFormDOM(TreeElement root) {
+        int numChildren = root.getNumChildren();
+        for (int i = 0; i < numChildren; i++) {
+            TreeElement child = root.getChildAt(i);
+            System.out.println("Form node: " + child.getName());
+            printFormDOM(child);
+        }
+    }
 
     /**
      * Sets the root element of this Model's tree

--- a/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -92,6 +92,7 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         return root.getChildAt(0);
     }
 
+
     /**
      * Sets the root element of this Model's tree
      *

--- a/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -92,19 +92,6 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         return root.getChildAt(0);
     }
 
-    public void printFormDOM() {
-        printFormDOM(this.root);
-    }
-
-    private void printFormDOM(TreeElement root) {
-        int numChildren = root.getNumChildren();
-        for (int i = 0; i < numChildren; i++) {
-            TreeElement child = root.getChildAt(i);
-            System.out.println("Form node: " + child.getName());
-            printFormDOM(child);
-        }
-    }
-
     /**
      * Sets the root element of this Model's tree
      *

--- a/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -235,17 +235,14 @@ public class FormEntryPrompt extends FormEntryCaption {
         }
     }
 
-    private boolean questionTextIsUnchanged(FormEntryPrompt oldPrompt) {
-        String newQuestionText = getQuestionText();
-        String oldQuestionText = oldPrompt.getQuestionText();
-        return newQuestionText.equals(oldQuestionText);
+    private boolean questionTextIsUnchanged(String oldQuestionText) {
+        return getQuestionText().equals(oldQuestionText);
     }
 
-    public boolean hasSameDisplayContent(FormEntryPrompt oldPrompt,
+    public boolean hasSameDisplayContent(String questionTextForOldPrompt,
                                          Vector<SelectChoice> selectChoicesForOldPrompt) {
-        //this.form.getMainInstance().printFormDOM();
-        return selectAreChoicesUnchanged(selectChoicesForOldPrompt) &&
-                questionTextIsUnchanged(oldPrompt);
+        return questionTextIsUnchanged(questionTextForOldPrompt) &&
+                selectAreChoicesUnchanged(selectChoicesForOldPrompt);
     }
 
     public boolean isRequired() {

--- a/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -209,7 +209,6 @@ public class FormEntryPrompt extends FormEntryCaption {
     public Vector<SelectChoice> getSelectChoices() { return getSelectChoices(true); }
     public Vector<SelectChoice> getSelectChoices(boolean shouldAttemptDynamicPopulation) {
         QuestionDef q = getQuestion();
-
         ItemsetBinding itemset = q.getDynamicChoices();
         if (itemset != null) {
             if (shouldAttemptDynamicPopulation && !dynamicChoicesPopulated) {
@@ -225,6 +224,16 @@ public class FormEntryPrompt extends FormEntryCaption {
 
     public Vector<SelectChoice> getOldSelectChoices() {
         return getSelectChoices(false);
+    }
+
+    /**
+     * @return If this prompt has all of the same display content as a previous prompt that had
+     * the given question text and select choices
+     */
+    public boolean hasSameDisplayContent(String questionTextForOldPrompt,
+                                         Vector<SelectChoice> selectChoicesForOldPrompt) {
+        return questionTextIsUnchanged(questionTextForOldPrompt) &&
+                selectChoicesAreUnchanged(selectChoicesForOldPrompt);
     }
 
     private boolean selectChoicesAreUnchanged(Vector<SelectChoice> choicesForOld) {
@@ -243,16 +252,6 @@ public class FormEntryPrompt extends FormEntryCaption {
         } else {
             return newQuestionText.equals(oldQuestionText);
         }
-    }
-
-    /**
-     * @return If this prompt has all of the same display content as a previous prompt that had
-     * the given question text and select choices
-     */
-    public boolean hasSameDisplayContent(String questionTextForOldPrompt,
-                                         Vector<SelectChoice> selectChoicesForOldPrompt) {
-        return questionTextIsUnchanged(questionTextForOldPrompt) &&
-                selectChoicesAreUnchanged(selectChoicesForOldPrompt);
     }
 
     public boolean isRequired() {

--- a/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -227,7 +227,7 @@ public class FormEntryPrompt extends FormEntryCaption {
         return getSelectChoices(false);
     }
 
-    private boolean selectAreChoicesUnchanged(Vector<SelectChoice> choicesForOld) {
+    private boolean selectChoicesAreUnchanged(Vector<SelectChoice> choicesForOld) {
         Vector<SelectChoice> choicesForThis = getSelectChoices();
         if (choicesForOld == null) {
             return choicesForThis == null;
@@ -252,7 +252,7 @@ public class FormEntryPrompt extends FormEntryCaption {
     public boolean hasSameDisplayContent(String questionTextForOldPrompt,
                                          Vector<SelectChoice> selectChoicesForOldPrompt) {
         return questionTextIsUnchanged(questionTextForOldPrompt) &&
-                selectAreChoicesUnchanged(selectChoicesForOldPrompt);
+                selectChoicesAreUnchanged(selectChoicesForOldPrompt);
     }
 
     public boolean isRequired() {

--- a/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -245,6 +245,10 @@ public class FormEntryPrompt extends FormEntryCaption {
         }
     }
 
+    /**
+     * @return If this prompt has all of the same display content as a previous prompt that had
+     * the given question text and select choices
+     */
     public boolean hasSameDisplayContent(String questionTextForOldPrompt,
                                          Vector<SelectChoice> selectChoicesForOldPrompt) {
         return questionTextIsUnchanged(questionTextForOldPrompt) &&

--- a/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -206,12 +206,13 @@ public class FormEntryPrompt extends FormEntryCaption {
         }
     }
 
-    public Vector<SelectChoice> getSelectChoices() {
+    public Vector<SelectChoice> getSelectChoices() { return getSelectChoices(true); }
+    public Vector<SelectChoice> getSelectChoices(boolean shouldAttemptDynamicPopulation) {
         QuestionDef q = getQuestion();
 
         ItemsetBinding itemset = q.getDynamicChoices();
         if (itemset != null) {
-            if (!dynamicChoicesPopulated) {
+            if (shouldAttemptDynamicPopulation && !dynamicChoicesPopulated) {
                 form.populateDynamicChoices(itemset, mTreeElement.getRef());
                 dynamicChoicesPopulated = true;
             }
@@ -219,6 +220,32 @@ public class FormEntryPrompt extends FormEntryCaption {
         } else { //static choices
             return q.getChoices();
         }
+    }
+
+    public Vector<SelectChoice> getOldSelectChoices() {
+        return getSelectChoices(false);
+    }
+
+    private boolean selectAreChoicesUnchanged(Vector<SelectChoice> choicesForOld) {
+        Vector<SelectChoice> choicesForThis = getSelectChoices();
+        if (choicesForOld == null) {
+            return choicesForThis == null;
+        } else {
+            return choicesForOld.equals(choicesForThis);
+        }
+    }
+
+    private boolean questionTextIsUnchanged(FormEntryPrompt oldPrompt) {
+        String newQuestionText = getQuestionText();
+        String oldQuestionText = oldPrompt.getQuestionText();
+        return newQuestionText.equals(oldQuestionText);
+    }
+
+    public boolean hasSameDisplayContent(FormEntryPrompt oldPrompt,
+                                         Vector<SelectChoice> selectChoicesForOldPrompt) {
+        //this.form.getMainInstance().printFormDOM();
+        return selectAreChoicesUnchanged(selectChoicesForOldPrompt) &&
+                questionTextIsUnchanged(oldPrompt);
     }
 
     public boolean isRequired() {

--- a/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
+++ b/core/src/main/java/org/javarosa/form/api/FormEntryPrompt.java
@@ -217,7 +217,8 @@ public class FormEntryPrompt extends FormEntryCaption {
                 dynamicChoicesPopulated = true;
             }
             return itemset.getChoices();
-        } else { //static choices
+        } else {
+            // static choices
             return q.getChoices();
         }
     }
@@ -236,7 +237,12 @@ public class FormEntryPrompt extends FormEntryCaption {
     }
 
     private boolean questionTextIsUnchanged(String oldQuestionText) {
-        return getQuestionText().equals(oldQuestionText);
+        String newQuestionText = getQuestionText();
+        if (newQuestionText == null) {
+            return oldQuestionText == null;
+        } else {
+            return newQuestionText.equals(oldQuestionText);
+        }
     }
 
     public boolean hasSameDisplayContent(String questionTextForOldPrompt,


### PR DESCRIPTION
Previously, if the question text or select options for one question in a question list were dependent upon the answer to a prior question in the group, the question text / select options would NOT get updated when a user changed their answer to the prior question. This fixes that.

cross: https://github.com/dimagi/commcare-odk/pull/762