### PR TITLE
Fix for recalculate equality checks

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -28,7 +28,7 @@ public class Recalculate extends Triggerable {
     public Recalculate(IConditionExpr expr, TreeReference contextRef) {
         super(expr, contextRef);
     }
-    
+
     @Override
     public Object eval(FormInstance model, EvaluationContext ec) {
         try {
@@ -122,10 +122,8 @@ public class Recalculate extends Triggerable {
 
 
     /**
-     * Conditions are equal if they have the same actions, expression, and
-     * triggers, but NOT targets or context ref.
+     * Recalculates are equal based on their triggers and identity as a calculate triggerable
      */
-
     public boolean equals(Object o) {
         if (o instanceof Recalculate) {
             Recalculate r = (Recalculate)o;

--- a/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -28,8 +28,8 @@ public class Recalculate extends Triggerable {
     public Recalculate(IConditionExpr expr, TreeReference contextRef) {
         super(expr, contextRef);
     }
-
-
+    
+    @Override
     public Object eval(FormInstance model, EvaluationContext ec) {
         try {
             return expr.evalRaw(model, ec);
@@ -39,13 +39,13 @@ public class Recalculate extends Triggerable {
         }
     }
 
-
+    @Override
     public void apply(TreeReference ref, Object result, FormInstance model, FormDef f) {
         int dataType = f.getMainInstance().resolveReference(ref).getDataType();
         f.setAnswer(wrapData(result, dataType), ref);
     }
 
-
+    @Override
     public boolean canCascade() {
         return true;
     }

--- a/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -134,6 +134,11 @@ public class Recalculate extends Triggerable {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return "calculate".hashCode() ^ super.hashCode();
+    }
+
 
     public String getDebugLabel() {
         return "calculate";

--- a/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -29,7 +29,7 @@ public class Recalculate extends Triggerable {
         super(expr, contextRef);
     }
 
-    @Override
+
     public Object eval(FormInstance model, EvaluationContext ec) {
         try {
             return expr.evalRaw(model, ec);
@@ -39,13 +39,13 @@ public class Recalculate extends Triggerable {
         }
     }
 
-    @Override
+
     public void apply(TreeReference ref, Object result, FormInstance model, FormDef f) {
         int dataType = f.getMainInstance().resolveReference(ref).getDataType();
         f.setAnswer(wrapData(result, dataType), ref);
     }
 
-    @Override
+
     public boolean canCascade() {
         return true;
     }
@@ -120,7 +120,21 @@ public class Recalculate extends Triggerable {
         }
     }
 
-    @Override
+
+    /**
+     * Conditions are equal if they have the same actions, expression, and
+     * triggers, but NOT targets or context ref.
+     */
+
+    public boolean equals(Object o) {
+        if (o instanceof Recalculate) {
+            Recalculate r = (Recalculate)o;
+            return (this == r || super.equals(r));
+        }
+        return false;
+    }
+
+
     public String getDebugLabel() {
         return "calculate";
     }

--- a/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Recalculate.java
@@ -124,6 +124,7 @@ public class Recalculate extends Triggerable {
     /**
      * Recalculates are equal based on their triggers and identity as a calculate triggerable
      */
+    @Override
     public boolean equals(Object o) {
         if (o instanceof Recalculate) {
             Recalculate r = (Recalculate)o;


### PR DESCRIPTION
Fixes:
http://manage.dimagi.com/default.asp?185916#BugEvent.1037054

Fix for issue with recalculates not implementing .equals, resulting in it being possible for a recalculate to equal another trigger from the parent logic.