### PR TITLE
Check for DateTimeData in unpackValue

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/data/DateTimeData.java
+++ b/core/src/main/java/org/javarosa/core/model/data/DateTimeData.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.core.model.data;
 
 import org.javarosa.core.model.utils.DateUtils;
@@ -46,10 +30,12 @@ public class DateTimeData implements IAnswerData {
         setValue(d);
     }
 
+    @Override
     public IAnswerData clone() {
         return new DateTimeData(new Date(d.getTime()));
     }
 
+    @Override
     public void setValue(Object o) {
         //Should not ever be possible to set this to a null value
         if (o == null) {
@@ -58,6 +44,7 @@ public class DateTimeData implements IAnswerData {
         d = new Date(((Date)o).getTime());
     }
 
+    @Override
     public Object getValue() {
         return new Date(d.getTime());
     }
@@ -66,24 +53,22 @@ public class DateTimeData implements IAnswerData {
         return DateUtils.formatDateTime(d, DateUtils.FORMAT_HUMAN_READABLE_SHORT);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.utilities.Externalizable#readExternal(java.io.DataInputStream)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         setValue(ExtUtil.readDate(in));
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.services.storage.utilities.Externalizable#writeExternal(java.io.DataOutputStream)
-     */
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeDate(out, d);
     }
 
+    @Override
     public UncastData uncast() {
         return new UncastData(DateUtils.formatDateTime(d, DateUtils.FORMAT_ISO8601));
     }
 
+    @Override
     public DateTimeData cast(UncastData data) throws IllegalArgumentException {
         Date ret = DateUtils.parseDateTime(data.value);
         if (ret != null) {

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -4,6 +4,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
+import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
@@ -253,6 +254,8 @@ public class XPathPathExpr extends XPathExpression {
         } else if (val instanceof SelectMultiData) {
             return (new XFormAnswerDataSerializer()).serializeAnswerData(val);
         } else if (val instanceof DateData) {
+            return val.getValue();
+        } else if (val instanceof DateTimeData) {
             return val.getValue();
         } else if (val instanceof BooleanData) {
             return val.getValue();


### PR DESCRIPTION
Don't really understand the implications of this change, but Sheel was getting `warning: unrecognized data type in xpath expr: org.javarosa.core.model.data.DateTimeData` and this fixes that.

Might be a fix for http://manage.dimagi.com/default.asp?186983