### PR TITLE
Contextualization was conflating attributes and normal nodes of the same name

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -988,8 +988,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 if (genericRoot.isParentOf(target, false)) {
                     if (!triggeredDuringInsert.contains(triggerable)) {
                         applicable.addElement(triggerable);
+                        break;
                     }
-                    break;
                 }
             }
         }

--- a/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -452,8 +452,14 @@ public class TreeReference implements Externalizable {
             if (contextRef.getName(i).equals(newRef.getName(i))) {
                 // Only copy over multiplicity info if it won't overwrite any
                 // existing preds or filters
+
+                // don't copy multiplicity from context when new ref's
+                // multiplicity is already bound or when the context's
+                // multiplicity is not a position (but rather an attr or
+                // template)
                 if (newRef.getPredicate(i) == null &&
-                        newRef.getMultiplicity(i) == INDEX_UNBOUND) {
+                        newRef.getMultiplicity(i) == INDEX_UNBOUND &&
+                        contextRef.getMultiplicity(i) >= 0) {
                     newRef.setMultiplicity(i, contextRef.getMultiplicity(i));
                 }
             } else {

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -237,7 +237,11 @@ public class FormDefTest {
         // make sure the language isn't the default language, 'esperanto',
         // which it is initially set to
         ExprEvalUtils.assertEqualsXpathEval("Check language set correctly",
-                "en", "/data/country[1]/language", evalCtx);
+                "en", "/data/iter/country[1]/language", evalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("Check id attr set correctly",
+                "1", "/data/iter/country[2]/@id", evalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("Check id node set correctly",
+                "1", "/data/iter/country[2]/id", evalCtx);
     }
 
     /**

--- a/core/src/test/resources/xform_tests/test_repeat_insert_duplicate_triggering.xml
+++ b/core/src/test/resources/xform_tests/test_repeat_insert_duplicate_triggering.xml
@@ -16,19 +16,28 @@
                         <language short="ur">urdu</language>
                     </languages>
 
-                    <country id="" jr:template="">
-                        <language/>
-                        <population year_observed=""/>
-                    </country>
+                    <iter current_index="">
+                        <country id="" jr:template="">
+                            <language/>
+                            <population year_observed=""/>
+                            <id/>
+                        </country>
+                    </iter>
                 </data>
             </instance>
 
             <bind nodeset="/data/how_many" type="xsd:int"/>
             <bind nodeset="/data/default_language"/>
-            <bind nodeset="/data/country"/>
+            <bind nodeset="/data/iter/country"/>
+
+            <!-- test that attr and node with identical names aren't conflated -->
+            <bind
+                calculate="current()/../@id"
+                nodeset="/data/iter/country/id"/>
 
             <bind calculate="count(/data/languages) + 1 + int(random()*10000)"
-                  nodeset="/data/country/population"/>
+                  nodeset="/data/iter/country/population"/>
+            <bind nodeset="/data/iter/@current_index" calculate="int(count(/data/iter/country))"/>
 
             <!--
             Calculating the country language will get triggered twice:
@@ -40,14 +49,15 @@
             -->
             <bind
                 calculate="if(current()/../population > 0, /data/languages/language[((int(current()/../@id)) mod count(/data/languages)) + 1]/@short, /data/default_language)"
-                nodeset="/data/country/language"/>
+                nodeset="/data/iter/country/language"/>
 
             <setvalue event="xforms-ready" ref="/data/how_many" value="4"/>
             <setvalue event="xforms-ready" ref="/data/default_language" value="'esperanto'"/>
 
             <!-- inserting a new entry will set the @id, triggering the countries language to be set -->
-            <setvalue event="jr-insert" ref="/data/country/@id" value="int(count(/data/country))"/>
-            <setvalue event="jr-insert" ref="/data/country/language" value="'esperanto'"/>
+
+            <setvalue event="jr-insert" ref="/data/iter/country/@id" value="/data/iter/@current_index"/>
+            <setvalue event="jr-insert" ref="/data/iter/country/language" value="'esperanto'"/>
 
             <itext>
                 <translation default="" lang="en">
@@ -64,7 +74,7 @@
     <h:body>
         <group>
             <label ref="jr:itext('country-label')"/>
-            <repeat nodeset="/data/country" jr:count="/data/how_many" jr:noAddRemove="true()"/>
+            <repeat nodeset="/data/iter/country" jr:count="/data/how_many" jr:noAddRemove="true()"/>
         </group>
     </h:body>
 </h:html>


### PR DESCRIPTION
When we contextualize the `current()` in something like `<bind nodeset="/data/treatments/iterate_over_meds/item/id" calculate="current()/../@id"/>` we conflate `@id` and `/id`, such that `@id` gets set instead of `/id`.

This wasn't coming up because we were always re-triggering thing twice which somehow hid this issue. But since https://github.com/dimagi/javarosa/pull/174 triggers are only fired once, so this issue arises.

The test cases I added fail when the fix is absent.

http://manage.dimagi.com/default.asp?188205