### PR TITLE
Serialize attributes correctly & add serialization tests

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -409,9 +409,17 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
 
 
     /**
-     * Custom externalization reader used to migrate fixtures from CommCare 2.24 to 2.25
+     * Custom deserializer for migrating fixtures off of CommCare 2.24.
      *
-     * This can be removed once we are certain no devices will be migrated up from 2.24
+     * The migration is needed because attribute serialization was redone to
+     * capture data-type information.  If this migration is not performed
+     * between 2.24 and subsequent versions, fixtures can not be opened. If the
+     * migration fails the user can always sync, clear user data, and restore
+     * to get reload the fixtures.
+     *
+     * Used in Android app db migration V.7 and user db migration V.9
+     *
+     * This can be removed once no devices running 2.24 remain
      */
     public void migrateSerialization(DataInputStream in, PrototypeFactory pf)
             throws IOException, DeserializationException {

--- a/core/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -285,21 +285,43 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         int i = children.size();
         if (child.getMult() == TreeReference.INDEX_TEMPLATE) {
             TreeElement anchor = getChild(child.getName(), 0);
-            if (anchor != null)
-                i = children.indexOf(anchor);
+            if (anchor != null) {
+                i = referenceIndexOf(children, anchor);
+            }
         } else {
             TreeElement anchor = getChild(child.getName(),
                     (child.getMult() == 0 ? TreeReference.INDEX_TEMPLATE : child.getMult() - 1));
-            if (anchor != null)
-                i = children.indexOf(anchor) + 1;
+            if (anchor != null) {
+                i = referenceIndexOf(children, anchor) + 1;
+            }
         }
         children.insertElementAt(child, i);
-        child.setParent(this);
 
-        child.setRelevant(isRelevant(), true);
-        child.setEnabled(isEnabled(), true);
-        child.setInstanceName(getInstanceName());
+        initAddedSubNode(child);
     }
+
+    /**
+     * Implementation of Vector.indexOf that avoids calling TreeElement.equals,
+     * which is very slow.
+     */
+    private static int referenceIndexOf(Vector list, Object potentialEntry) {
+        for (int i = 0; i < list.size(); i++) {
+            Object element = list.get(i);
+            if (potentialEntry == element) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void initAddedSubNode(TreeElement node) {
+        node.setParent(this);
+        node.setRelevant(isRelevant(), true);
+        node.setEnabled(isEnabled(), true);
+        node.setInstanceName(getInstanceName());
+    }
+
+
 
     /* (non-Javadoc)
      * @see org.javarosa.core.model.instance.AbstractTreeElement#removeChild(org.javarosa.core.model.instance.TreeElement)
@@ -373,12 +395,12 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         newNode.instanceName = instanceName;
         newNode.namespace = namespace;
 
-        newNode.setAttributesFromSingleStringVector(getSingleStringAttributeVector());
         if (value != null) {
             newNode.value = value.clone();
         }
 
         newNode.children = children;
+        newNode.attributes = attributes;
         return newNode;
     }
 
@@ -398,8 +420,32 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
             }
         }
 
+        if (attributes != null) {
+            newNode.attributes = new Vector<TreeElement>();
+            for (TreeElement attr : attributes) {
+                if (includeTemplates || attr.getMult() != TreeReference.INDEX_TEMPLATE) {
+                    newNode.addAttribute(attr.deepCopy(includeTemplates));
+                }
+            }
+        }
+
         return newNode;
     }
+
+    private void addAttribute(TreeElement attr) {
+        if (attr.multiplicity != TreeReference.INDEX_ATTRIBUTE) {
+            throw new RuntimeException("Attribute doesn't have the correct index!");
+        }
+
+        if (attributes == null) {
+            attributes = new Vector<TreeElement>();
+        }
+
+        attributes.addElement(attr);
+
+        initAddedSubNode(attr);
+    }
+
 
     /* ==== MODEL PROPERTIES ==== */
 
@@ -648,6 +694,13 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         if (attributes == null) {
             this.attributes = new Vector<TreeElement>();
         }
+
+        if ("".equals(namespace)) {
+            // normalize to match how non-attribute TreeElements store namespaces
+            // NOTE PLM: "" and null are quite conflated, especially in read/writeExternal.
+            namespace = null;
+        }
+
         for (int i = attributes.size() - 1; i >= 0; i--) {
             TreeElement attribut = attributes.elementAt(i);
             if (attribut.name.equals(name) && (namespace == null || namespace.equals(attribut.namespace))) {
@@ -660,10 +713,6 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
             }
         }
 
-        if (namespace == null) {
-            namespace = "";
-        }
-
         TreeElement attr = TreeElement.constructAttributeElement(namespace, name);
         attr.setValue(new UncastData(value));
         attr.setParent(this);
@@ -671,155 +720,16 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         attributes.addElement(attr);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.core.model.instance.AbstractTreeElement#getSingleStringAttributeVector()
-     */
-    public Vector getSingleStringAttributeVector() {
-        Vector strings = new Vector();
-        if (attributes == null || attributes.size() == 0)
-            return null;
-        else {
-            for (int i = 0; i < this.attributes.size(); i++) {
-                TreeElement attribute = attributes.elementAt(i);
-                String value = getAttributeValue(attribute);
-                if (attribute.namespace == null || attribute.namespace.equals(""))
-                    strings.addElement(new String(attribute.getName() + "=" + value));
-                else
-                    strings.addElement(new String(attribute.namespace + ":" + attribute.getName()
-                            + "=" + value));
-            }
-            return strings;
-        }
-    }
-
-    /* (non-Javadoc)
-     * @see org.javarosa.core.model.instance.AbstractTreeElement#setAttributesFromSingleStringVector(java.util.Vector)
-     */
-    public void setAttributesFromSingleStringVector(Vector attStrings) {
-        if (attStrings != null) {
-            this.attributes = new Vector(0);
-            for (int i = 0; i < attStrings.size(); i++) {
-                addSingleAttribute(i, attStrings);
-            }
-        }
-    }
-
-    private void addSingleAttribute(int i, Vector attStrings) {
-        String att = (String)attStrings.elementAt(i);
-        String[] array = new String[3];
-
-        int pos = -1;
-
-        //TODO: The only current assumption here is that the namespace/name of the attribute doesn't have
-        //an equals sign in it. I think this is safe. not sure.
-
-        //Split into first and second parts
-        pos = att.indexOf("=");
-
-        //put the value in our output
-        array[2] = att.substring(pos + 1);
-
-        //now we're left with the xmlns (possibly) and the
-        //name. Get that into a single string.
-        att = att.substring(0, pos);
-
-        //reset position marker.
-        pos = -1;
-
-        // Clayton Sims - Jun 1, 2009 : Updated this code:
-        //    We want to find the _last_ possible ':', not the
-        // first one. Namespaces can have URLs in them.
-        //int pos = att.indexOf(":");
-        while (att.indexOf(":", pos + 1) != -1) {
-            pos = att.indexOf(":", pos + 1);
-        }
-
-        if (pos == -1) {
-            //No namespace
-            array[0] = null;
-
-            //for the name eval below
-            pos = 0;
-        } else {
-            //there is a namespace, grab it
-            array[0] = att.substring(0, pos);
-        }
-        // Now get the name part
-        array[1] = att.substring(pos);
-
-        this.setAttribute(array[0], array[1], array[2]);
-    }
-
     /* ==== SERIALIZATION ==== */
 
-    /*
-     * TODO:
-     *
-     * this new serialization scheme is kind of lame. ideally, we shouldn't have
-     * to sub-class TreeElement at all; we should have an API that can
-     * seamlessly represent complex data model objects (like weight history or
-     * immunizations) as if they were explicity XML subtrees underneath the
-     * parent TreeElement
-     *
-     * failing that, we should wrap this scheme in an ExternalizableWrapper
-     */
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.javarosa.core.services.storage.utilities.Externalizable#readExternal
-     * (java.io.DataInputStream)
-     */
-    /* (non-Javadoc)
-     * @see org.javarosa.core.model.instance.AbstractTreeElement#readExternal(java.io.DataInputStream, org.javarosa.core.util.externalizable.PrototypeFactory)
-     */
+    @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         name = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         multiplicity = ExtUtil.readInt(in);
         flags = ExtUtil.readInt(in);
         value = (IAnswerData)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
 
-        // children = ExtUtil.nullIfEmpty((Vector)ExtUtil.read(in, new
-        // ExtWrapList(TreeElement.class), pf));
-
-        // Jan 22, 2009 - csims@dimagi.com
-        // old line: children = ExtUtil.nullIfEmpty((Vector)ExtUtil.read(in, new
-        // ExtWrapList(TreeElement.class), pf));
-        // New Child deserialization
-        // 1. read null status as boolean
-        // 2. read number of children
-        // 3. for i < number of children
-        // 3.1 if read boolean true , then create TreeElement and deserialize
-        // directly.
-        // 3.2 if read boolean false then create tagged element and deserialize
-        // child
-        if (!ExtUtil.readBool(in)) {
-            // 1.
-            children = null;
-        } else {
-            children = new Vector();
-            // 2.
-            int numChildren = (int)ExtUtil.readNumeric(in);
-            // 3.
-            for (int i = 0; i < numChildren; ++i) {
-                boolean normal = ExtUtil.readBool(in);
-                TreeElement child;
-
-                if (normal) {
-                    // 3.1
-                    child = new TreeElement();
-                    child.readExternal(in, pf);
-                } else {
-                    // 3.2
-                    child = (TreeElement)ExtUtil.read(in, new ExtWrapTagged(), pf);
-                }
-                child.setParent(this);
-                children.addElement(child);
-            }
-        }
-
-        // end Jan 22, 2009
+        readChildrenFromExternal(in, pf);
 
         dataType = ExtUtil.readInt(in);
         instanceName = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
@@ -829,63 +739,47 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         preloadParams = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         namespace = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
 
-        Vector attStrings = ExtUtil.nullIfEmpty((Vector)ExtUtil.read(in,
-                new ExtWrapList(String.class), pf));
-        setAttributesFromSingleStringVector(attStrings);
+        readAttributesFromExternal(in, pf);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.javarosa.core.services.storage.utilities.Externalizable#writeExternal
-     * (java.io.DataOutputStream)
-     */
-    /* (non-Javadoc)
-     * @see org.javarosa.core.model.instance.AbstractTreeElement#writeExternal(java.io.DataOutputStream)
-     */
+    private void readChildrenFromExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        if (!ExtUtil.readBool(in)) {
+            children = null;
+        } else {
+            children = new Vector<TreeElement>();
+            int numChildren = (int)ExtUtil.readNumeric(in);
+            for (int i = 0; i < numChildren; ++i) {
+                TreeElement child = new TreeElement();
+                child.readExternal(in, pf);
+                child.setParent(this);
+                children.addElement(child);
+            }
+        }
+    }
+
+    private void readAttributesFromExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        if (!ExtUtil.readBool(in)) {
+            attributes = null;
+        } else {
+            attributes = new Vector<TreeElement>();
+            int attrCount = (int)ExtUtil.readNumeric(in);
+            for (int i = 0; i < attrCount; ++i) {
+                TreeElement attr = new TreeElement();
+                attr.readExternal(in, pf);
+                attr.setParent(this);
+                attributes.addElement(attr);
+            }
+        }
+    }
+
+    @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(name));
         ExtUtil.writeNumeric(out, multiplicity);
         ExtUtil.writeNumeric(out, flags);
         ExtUtil.write(out, new ExtWrapNullable(value == null ? null : new ExtWrapTagged(value)));
 
-        // Jan 22, 2009 - csims@dimagi.com
-        // old line: ExtUtil.write(out, new
-        // ExtWrapList(ExtUtil.emptyIfNull(children)));
-        // New Child serialization
-        // 1. write null status as boolean
-        // 2. write number of children
-        // 3. for all child in children
-        // 3.1 if child type == TreeElement write boolean true , then serialize
-        // directly.
-        // 3.2 if child type != TreeElement, write boolean false, then tagged
-        // child
-        if (children == null) {
-            // 1.
-            ExtUtil.writeBool(out, false);
-        } else {
-            // 1.
-            ExtUtil.writeBool(out, true);
-            // 2.
-            ExtUtil.writeNumeric(out, children.size());
-            // 3.
-            Enumeration en = children.elements();
-            while (en.hasMoreElements()) {
-                TreeElement child = (TreeElement)en.nextElement();
-                if (child.getClass() == TreeElement.class) {
-                    // 3.1
-                    ExtUtil.writeBool(out, true);
-                    child.writeExternal(out);
-                } else {
-                    // 3.2
-                    ExtUtil.writeBool(out, false);
-                    ExtUtil.write(out, new ExtWrapTagged(child));
-                }
-            }
-        }
-
-        // end Jan 22, 2009
+        writeChildrenToExternal(out);
 
         ExtUtil.writeNumeric(out, dataType);
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(instanceName));
@@ -894,9 +788,37 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(preloadParams));
         ExtUtil.writeString(out, ExtUtil.emptyIfNull(namespace));
 
-        Vector attStrings = getSingleStringAttributeVector();
-        ExtUtil.write(out, new ExtWrapList(ExtUtil.emptyIfNull(attStrings)));
+        writeAttributesToExternal(out);
     }
+
+    private void writeChildrenToExternal(DataOutputStream out) throws IOException {
+        if (children == null) {
+            ExtUtil.writeBool(out, false);
+        } else {
+            ExtUtil.writeBool(out, true);
+            ExtUtil.writeNumeric(out, children.size());
+            Enumeration en = children.elements();
+            while (en.hasMoreElements()) {
+                TreeElement child = (TreeElement)en.nextElement();
+                child.writeExternal(out);
+            }
+        }
+    }
+
+    private void writeAttributesToExternal(DataOutputStream out) throws IOException {
+        if (attributes == null) {
+            ExtUtil.writeBool(out, false);
+        } else {
+            ExtUtil.writeBool(out, true);
+            ExtUtil.writeNumeric(out, attributes.size());
+            Enumeration en = attributes.elements();
+            while (en.hasMoreElements()) {
+                TreeElement attr = (TreeElement)en.nextElement();
+                attr.writeExternal(out);
+            }
+        }
+    }
+
 
     /**
      * Rebuilding this node from an imported instance
@@ -1244,5 +1166,192 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
      */
     public Vector<TreeReference> tryBatchChildFetch(String name, int mult, Vector<XPathExpression> predicates, EvaluationContext evalContext) {
         return TreeUtilities.tryBatchChildFetch(this, mChildStepMapping, name, mult, predicates, evalContext);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        // NOTE PLM: does not compare equality of parents because that requires
+        // trickery to avoid looping indefinitely
+        if (o instanceof TreeElement) {
+            TreeElement otherTreeElement = (TreeElement)o;
+            final boolean doFieldsMatch = (name.equals(otherTreeElement.name) &&
+                    multiplicity == otherTreeElement.multiplicity &&
+                    flags == otherTreeElement.flags &&
+                    dataType == otherTreeElement.dataType &&
+                    ((instanceName != null && instanceName.equals(otherTreeElement.instanceName)) ||
+                            (instanceName == null && otherTreeElement.instanceName == null)) &&
+                    ((constraint != null && constraint.equals(otherTreeElement.constraint)) ||
+                            (constraint == null && otherTreeElement.constraint == null)) &&
+                    ((preloadHandler != null && preloadHandler.equals(otherTreeElement.preloadHandler)) ||
+                            (preloadHandler == null && otherTreeElement.preloadHandler == null)) &&
+                    ((preloadParams != null && preloadParams.equals(otherTreeElement.preloadParams)) ||
+                            (preloadParams == null && otherTreeElement.preloadParams == null)) &&
+                    ((namespace != null && namespace.equals(otherTreeElement.namespace)) ||
+                            (namespace == null && otherTreeElement.namespace == null)) &&
+                    ((value != null && value.uncast().getString().equals(otherTreeElement.value.uncast().getString())) ||
+                            value == null && otherTreeElement.value == null));
+            if (doFieldsMatch) {
+                if (children != null) {
+                    if (otherTreeElement.children == null) {
+                        return false;
+                    }
+                    for (TreeElement child : children) {
+                        if (!otherTreeElement.children.contains(child)) {
+                            return false;
+                        }
+                    }
+                } else {
+                    if (otherTreeElement.children != null) {
+                        return false;
+                    }
+                }
+                if (attributes != null) {
+                    if (otherTreeElement.attributes == null) {
+                        return false;
+                    }
+                    for (TreeElement attr : attributes) {
+                        if (!otherTreeElement.attributes.contains(attr)) {
+                            return false;
+                        }
+                    }
+                } else {
+                    if (otherTreeElement.attributes != null) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int childrenHashCode = 0;
+        if (children != null) {
+            for (TreeElement child : children) {
+                childrenHashCode ^= child.hashCode();
+            }
+        }
+
+        int attributesHashCode = 0;
+        if (attributes != null) {
+            for (TreeElement attr : attributes) {
+                attributesHashCode ^= attr.hashCode();
+            }
+        }
+
+        return multiplicity ^ flags ^ dataType ^
+                (instanceName == null ? 0 : instanceName.hashCode()) ^
+                (constraint == null ? 0 : constraint.hashCode()) ^
+                (preloadHandler == null ? 0 : preloadHandler.hashCode()) ^
+                (preloadParams == null ? 0 : preloadParams.hashCode()) ^
+                (namespace == null ? 0 : namespace.hashCode()) ^
+                (value == null ? 0 : value.hashCode()) ^
+                childrenHashCode ^ attributesHashCode;
+    }
+
+    /**
+     * Old externalization scheme used to migrate fixtures from CommCare 2.24 to 2.25
+     *
+     * This can be removed once we are certain no devices will be migrated up from 2.24
+     */
+    public void readExternalMigration(DataInputStream in, PrototypeFactory pf)
+            throws IOException, DeserializationException {
+        name = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        multiplicity = ExtUtil.readInt(in);
+        flags = ExtUtil.readInt(in);
+        value = (IAnswerData)ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
+
+        if (!ExtUtil.readBool(in)) {
+            children = null;
+        } else {
+            children = new Vector<TreeElement>();
+            int numChildren = (int)ExtUtil.readNumeric(in);
+            for (int i = 0; i < numChildren; ++i) {
+                boolean normal = ExtUtil.readBool(in);
+                TreeElement child;
+
+                if (normal) {
+                    child = new TreeElement();
+                    child.readExternalMigration(in, pf);
+                } else {
+                    child = (TreeElement)ExtUtil.read(in, new ExtWrapTagged(), pf);
+                }
+                child.setParent(this);
+                children.addElement(child);
+            }
+        }
+
+        dataType = ExtUtil.readInt(in);
+        instanceName = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        constraint = (Constraint)ExtUtil.read(in, new ExtWrapNullable(
+                Constraint.class), pf);
+        preloadHandler = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        preloadParams = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        namespace = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+
+        Vector attStrings = ExtUtil.nullIfEmpty((Vector)ExtUtil.read(in,
+                new ExtWrapList(String.class), pf));
+        setAttributesFromSingleStringVector(attStrings);
+    }
+
+    private void setAttributesFromSingleStringVector(Vector attStrings) {
+        if (attStrings != null) {
+            this.attributes = new Vector<TreeElement>();
+            for (int i = 0; i < attStrings.size(); i++) {
+                addSingleAttribute(i, attStrings);
+            }
+        }
+    }
+
+    private void addSingleAttribute(int i, Vector attStrings) {
+        String att = (String)attStrings.elementAt(i);
+        String[] array = new String[3];
+
+        int pos = -1;
+
+        //TODO: The only current assumption here is that the namespace/name of the attribute doesn't have
+        //an equals sign in it. I think this is safe. not sure.
+
+        //Split into first and second parts
+        pos = att.indexOf("=");
+
+        //put the value in our output
+        array[2] = att.substring(pos + 1);
+
+        //now we're left with the xmlns (possibly) and the
+        //name. Get that into a single string.
+        att = att.substring(0, pos);
+
+        //reset position marker.
+        pos = -1;
+
+        // Clayton Sims - Jun 1, 2009 : Updated this code:
+        //    We want to find the _last_ possible ':', not the
+        // first one. Namespaces can have URLs in them.
+        //int pos = att.indexOf(":");
+        while (att.indexOf(":", pos + 1) != -1) {
+            pos = att.indexOf(":", pos + 1);
+        }
+
+        if (pos == -1) {
+            //No namespace
+            array[0] = null;
+
+            //for the name eval below
+            pos = 0;
+        } else {
+            //there is a namespace, grab it
+            array[0] = att.substring(0, pos);
+        }
+        // Now get the name part
+        array[1] = att.substring(pos);
+
+        setAttribute(array[0], array[1], array[2]);
     }
 }

--- a/core/src/main/java/org/javarosa/core/util/externalizable/LivePrototypeFactory.java
+++ b/core/src/main/java/org/javarosa/core/util/externalizable/LivePrototypeFactory.java
@@ -1,0 +1,82 @@
+package org.javarosa.core.util.externalizable;
+
+import org.javarosa.core.api.ClassNameHasher;
+
+import java.util.Hashtable;
+
+/**
+ * A prototype factory that is configured to keep track of all of the
+ * case->hash pairs that it creates in order to use them for deserializaiton in
+ * the future.
+ *
+ * Will only work reliably if it is used synchronously to hash all values that
+ * are read, and should really only be expected to function for 'in memory'
+ * storage like mocks.
+ *
+ * TODO: unify with Android storage live factory mocker
+ *
+ * @author ctsims
+ */
+public class LivePrototypeFactory extends PrototypeFactory {
+    private final Hashtable<String, Class> factoryTable = new Hashtable<String, Class>();
+    private final LiveHasher mLiveHasher;
+
+    public LivePrototypeFactory() {
+        this(new ClassNameHasher());
+    }
+
+    public LivePrototypeFactory(Hasher hasher) {
+        this.mLiveHasher = new LiveHasher(this, hasher);
+        PrototypeFactory.setStaticHasher(this.mLiveHasher);
+    }
+
+    @Override
+    protected void lazyInit() {
+    }
+
+    @Override
+    public void addClass(Class c) {
+        byte[] hash = getLiveHasher().getHasher().getClassHashValue(c);
+        factoryTable.put(ExtUtil.printBytes(hash), c);
+    }
+
+    @Override
+    public Class getClass(byte[] hash) {
+        String key = ExtUtil.printBytes(hash);
+        return factoryTable.get(key);
+    }
+
+    @Override
+    public Object getInstance(byte[] hash) {
+        return PrototypeFactory.getInstance(getClass(hash));
+    }
+
+    public LiveHasher getLiveHasher(){
+        return this.mLiveHasher;
+    }
+
+    public class LiveHasher extends Hasher{
+        LivePrototypeFactory pf;
+        Hasher mHasher;
+        public LiveHasher(LivePrototypeFactory pf, Hasher mHasher){
+            this.pf = pf;
+            this.mHasher = mHasher;
+        }
+
+        @Override
+        public int getHashSize() {
+            return mHasher.getHashSize();
+        }
+
+        @Override
+        public byte[] getHash(Class c) {
+            byte[] ret = mHasher.getClassHashValue(c);
+            pf.addClass(c);
+            return ret;
+        }
+
+        public Hasher getHasher(){
+            return mHasher;
+        }
+    }
+}

--- a/core/src/test/java/org/javarosa/core/model/instance/test/FormInstanceTest.java
+++ b/core/src/test/java/org/javarosa/core/model/instance/test/FormInstanceTest.java
@@ -1,0 +1,126 @@
+package org.javarosa.core.model.instance.test;
+
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.LivePrototypeFactory;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.test_utils.ExprEvalUtils;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Date;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com).
+ */
+public class FormInstanceTest {
+    private static final LivePrototypeFactory pf = new LivePrototypeFactory();
+
+    /**
+     * Serialize/deserialize a form instance, ensuring the resulting roots are equal
+     */
+    @Test
+    public void testInstanceSerialization() {
+        FormParseInit fpi = new FormParseInit("/xform_tests/test_repeat_insert_duplicate_triggering.xml");
+        FormEntryController fec = fpi.getFormEntryController();
+        fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+
+        FormDef fd = fpi.getFormDef();
+        // run initialization to ensure xforms-ready event and binds are
+        // triggered.
+        fd.initialize(true, new DummyInstanceInitializationFactory());
+
+        FormInstance instance = fd.getMainInstance();
+        FormInstance reSerializedInstance = reSerializeFormInstance(instance);
+
+        assertTrue("Form instance root should be same after serialization",
+                instance.getRoot().equals(reSerializedInstance.getRoot()));
+    }
+
+    /**
+     * serialize a form instance then return the new deserialized instance
+     */
+    private static FormInstance reSerializeFormInstance(FormInstance originalInstance) {
+        FormInstance reSerializedInstance = null;
+        try {
+            reSerializedInstance = FormInstance.class.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            fail(e.getMessage());
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
+
+        try {
+            originalInstance.writeExternal(out);
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+        DataInputStream instanceStream = null;
+        try {
+            instanceStream = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+            reSerializedInstance.readExternal(instanceStream, pf);
+        } catch (IOException | DeserializationException e) {
+            fail(e.getMessage());
+        } finally {
+            if (instanceStream != null) {
+                try {
+                    instanceStream.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return reSerializedInstance;
+    }
+
+    /**
+     * Regression test that runs through form entry with a normally loaded
+     * form and a form that has been serialized then deserialized and compare
+     * answers on a question with a dateTime type.
+     */
+    @Test
+    public void testFormEntryAfterSerialization() throws XPathSyntaxException {
+        FormParseInit fpi = new FormParseInit("/xform_tests/test_repeat_insert_duplicate_triggering.xml");
+        FormEntryController fec = fpi.getFormEntryController();
+        fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+
+        FormDef fd = fpi.getFormDef();
+        // run initialization to ensure xforms-ready event and binds are
+        // triggered.
+        fd.initialize(true, new DummyInstanceInitializationFactory());
+        FormInstance instance = fd.getMainInstance();
+        do {
+        } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
+        EvaluationContext evalCtx = fd.getEvaluationContext();
+        Date modified = (Date)ExprEvalUtils.xpathEval(evalCtx, "/data/how_many/@date_modified");
+
+        FormInstance reSerializedInstance = reSerializeFormInstance(instance);
+
+        fd.setInstance(reSerializedInstance);
+        fd.initialize(true, new DummyInstanceInitializationFactory());
+        FormEntryModel femodel = new FormEntryModel(fd);
+        fec = new FormEntryController(femodel);
+        fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+
+        do {
+        } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
+        evalCtx = fd.getEvaluationContext();
+        Date modified2 = (Date)ExprEvalUtils.xpathEval(evalCtx, "/data/how_many/@date_modified");
+        assertTrue(modified.getTime() - modified2.getTime() < 3000);
+    }
+}

--- a/core/src/test/resources/xform_tests/test_repeat_insert_duplicate_triggering.xml
+++ b/core/src/test/resources/xform_tests/test_repeat_insert_duplicate_triggering.xml
@@ -9,7 +9,7 @@
                       uiVersion="1"
                       version="57"
                       xmlns="http://openrosa.org/formdesigner/313BF9C4-9DF3-4B92-A111-1AB7306EA8CA">
-                    <how_many/>
+                    <how_many date_modified=""/>
                     <default_language/>
                     <languages>
                         <language short="en">english</language>
@@ -27,6 +27,8 @@
             </instance>
 
             <bind nodeset="/data/how_many" type="xsd:int"/>
+            <bind calculate="now()"
+                  nodeset="/data/how_many/@date_modified" type="xsd:dateTime"/>
             <bind nodeset="/data/default_language"/>
             <bind nodeset="/data/iter/country"/>
 
@@ -37,7 +39,7 @@
 
             <bind calculate="count(/data/languages) + 1 + int(random()*10000)"
                   nodeset="/data/iter/country/population"/>
-            <bind nodeset="/data/iter/@current_index" calculate="int(count(/data/iter/country))"/>
+            <bind calculate="int(count(/data/iter/country))" nodeset="/data/iter/@current_index"/>
 
             <!--
             Calculating the country language will get triggered twice:
@@ -56,7 +58,8 @@
 
             <!-- inserting a new entry will set the @id, triggering the countries language to be set -->
 
-            <setvalue event="jr-insert" ref="/data/iter/country/@id" value="/data/iter/@current_index"/>
+            <setvalue event="jr-insert" ref="/data/iter/country/@id"
+                      value="/data/iter/@current_index"/>
             <setvalue event="jr-insert" ref="/data/iter/country/language" value="'esperanto'"/>
 
             <itext>


### PR DESCRIPTION
Serializing TreeElement's attributes looses the data type encoded in it, causing problems with data storage, like xforrm dateTime types being treated as dates.

Attribute serialization has always been broken but I think some redundancy in trigger firing has masked that fact. The issue has probably arisen now that I've optimized trigger firing.

__Has potential to increase size of serialized form instances by ~25%__

http://manage.dimagi.com/default.asp?188492

cross-requested with https://github.com/dimagi/commcare/pull/215 and https://github.com/dimagi/commcare-odk/pull/894