### PR TITLE
Fix for Navigation Bug with End-Form Repeats

### DIFF
--- a/core/src/main/java/org/javarosa/form/api/FormEntryModel.java
+++ b/core/src/main/java/org/javarosa/form/api/FormEntryModel.java
@@ -426,7 +426,7 @@ public class FormEntryModel {
             if (e instanceof GroupDef) {
                 GroupDef g = (GroupDef)e;
                 if (g.getRepeat() && g.getCountReference() != null) {
-                    IAnswerData count = getForm().getMainInstance().resolveReference(g.getConextualizedCountReference(index.getLocalReference())).getValue();
+                    IAnswerData count = getForm().getMainInstance().resolveReference(g.getConextualizedCountReference(index.getReference())).getValue();
                     if (count != null) {
                         int fullcount = -1;
                         try {

--- a/core/src/main/java/org/javarosa/form/api/FormEntryModel.java
+++ b/core/src/main/java/org/javarosa/form/api/FormEntryModel.java
@@ -432,7 +432,7 @@ public class FormEntryModel {
                         try {
                             fullcount = ((Integer)new IntegerData().cast(count.uncast()).getValue()).intValue();
                         } catch (IllegalArgumentException iae) {
-                            throw new RuntimeException("The repeat count value \"" + count.uncast().getString() + "\" at " + g.getConextualizedCountReference(index.getLocalReference()).toString() + " must be a number!");
+                            throw new RuntimeException("The repeat count value \"" + count.uncast().getString() + "\" at " + g.getConextualizedCountReference(index.getReference()).toString() + " must be a number!");
                         }
                         TreeReference ref = getForm().getChildInstanceRef(index);
                         TreeElement element = getForm().getMainInstance().resolveReference(ref);

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -6,11 +6,13 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.instance.test.DummyInstanceInitializationFactory;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.test_utils.ExprEvalUtils;
 import org.junit.Test;
 
@@ -284,4 +286,29 @@ public class FormDefTest {
                 "Relevancy of skipped genus entry should be irrelevant to, due to the way it is calculated",
                 "", "/data/disabled_species", evalCtx);
     }
+
+    /**
+     * Regressions around complex repeat behaviors
+     */
+    @Test
+    public void testLoopedRepeatIndexFetches() throws Exception {
+        FormParseInit fpi = new FormParseInit("/xform_tests/test_looped_form_index_fetch.xml");
+        FormEntryController fec = fpi.getFormEntryController();
+        fpi.getFormDef().initialize(true, null);
+        fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+
+        fec.stepToNextEvent();
+        fec.stepToNextEvent();
+
+        fec.answerQuestion(new IntegerData(2));
+        while(fec.stepToNextEvent() != FormEntryController.EVENT_QUESTION);
+
+        fec.answerQuestion(new UncastData("yes"));
+        while(fec.stepToNextEvent() != FormEntryController.EVENT_QUESTION) ;
+
+        fec.getNextIndex(fec.getModel().getFormIndex(), true);
+        fec.answerQuestion(new IntegerData(2));
+        fec.getNextIndex(fec.getModel().getFormIndex(), true);
+    }
+
 }

--- a/core/src/test/resources/xform_tests/test_looped_form_index_fetch.xml
+++ b/core/src/test/resources/xform_tests/test_looped_form_index_fetch.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>Base Replication</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/3728ACF8-F162-4957-8A3C-2AED980FD52A" uiVersion="1" version="1" name="Base Replication">
+                    <outer_group>
+                        <num_repeat_outer />
+                        <outer_repeat jr:template="">
+                            <display />
+                            <num_repeat_inner />
+                            <inner_repeat jr:template="">
+                                <placeholder />
+                            </inner_repeat>
+                        </outer_repeat>
+                    </outer_group>
+                </data>
+            </instance>
+            <bind nodeset="/data/outer_group" />
+            <bind nodeset="/data/outer_group/num_repeat_outer" type="xsd:int" />
+            <bind nodeset="/data/outer_group/outer_repeat" />
+            <bind nodeset="/data/outer_group/outer_repeat/display" />
+            <bind nodeset="/data/outer_group/outer_repeat/num_repeat_inner" type="xsd:int" relevant="/data/outer_group/outer_repeat/display = 'yes'" />
+            <bind nodeset="/data/outer_group/outer_repeat/inner_repeat" relevant="/data/outer_group/outer_repeat/display = 'yes'" />
+            <bind nodeset="/data/outer_group/outer_repeat/inner_repeat/placeholder" type="xsd:string" />
+            <itext>
+                <translation lang="en" default="">
+                    <text id="outer_group-label">
+                        <value>outer_group</value>
+                    </text>
+                    <text id="outer_group/num_repeat_outer-label">
+                        <value>num_repeat_outer</value>
+                    </text>
+                    <text id="outer_group/outer_repeat-label">
+                        <value>outer_repeat</value>
+                    </text>
+                    <text id="outer_group/outer_repeat/display-label">
+                        <value>display</value>
+                    </text>
+                    <text id="outer_group/outer_repeat/display-yes-label">
+                        <value>yes</value>
+                    </text>
+                    <text id="outer_group/outer_repeat/display-no-label">
+                        <value>no</value>
+                    </text>
+                    <text id="outer_group/outer_repeat/num_repeat_inner-label">
+                        <value>num_repeat_inner</value>
+                    </text>
+                    <text id="outer_group/outer_repeat/inner_repeat-label">
+                        <value>inner_repeat</value>
+                    </text>
+                    <text id="outer_group/outer_repeat/inner_repeat/placeholder-label">
+                        <value>placeholder</value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/outer_group">
+            <label ref="jr:itext('outer_group-label')" />
+            <input ref="/data/outer_group/num_repeat_outer">
+                <label ref="jr:itext('outer_group/num_repeat_outer-label')" />
+            </input>
+            <group>
+                <label ref="jr:itext('outer_group/outer_repeat-label')" />
+                <repeat jr:count="/data/outer_group/num_repeat_outer" jr:noAddRemove="true()" nodeset="/data/outer_group/outer_repeat">
+                    <select1 ref="/data/outer_group/outer_repeat/display">
+                        <label ref="jr:itext('outer_group/outer_repeat/display-label')" />
+                        <item>
+                            <label ref="jr:itext('outer_group/outer_repeat/display-yes-label')" />
+                            <value>yes</value>
+                        </item>
+                        <item>
+                            <label ref="jr:itext('outer_group/outer_repeat/display-no-label')" />
+                            <value>no</value>
+                        </item>
+                    </select1>
+                    <input ref="/data/outer_group/outer_repeat/num_repeat_inner">
+                        <label ref="jr:itext('outer_group/outer_repeat/num_repeat_inner-label')" />
+                    </input>
+                    <group>
+                        <label ref="jr:itext('outer_group/outer_repeat/inner_repeat-label')" />
+                        <repeat jr:count="/data/outer_group/outer_repeat/num_repeat_inner" jr:noAddRemove="true()" nodeset="/data/outer_group/outer_repeat/inner_repeat">
+                            <input ref="/data/outer_group/outer_repeat/inner_repeat/placeholder">
+                                <label ref="jr:itext('outer_group/outer_repeat/inner_repeat/placeholder-label')" />
+                            </input>
+                        </repeat>
+                    </group>
+                </repeat>
+            </group>
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Context: http://manage.dimagi.com/default.asp?188096#1057212

Fix for bug where repeats were attempting to be contextualized against an incomplete reference when their creation was forced due to navigation. Basically we were using the "local" portion of a form index's reference, the piece for the current 'step' instead of representing the full index.