### PR TITLE
J2ME: get -> elementAt

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -306,7 +306,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
      */
     private static int referenceIndexOf(Vector list, Object potentialEntry) {
         for (int i = 0; i < list.size(); i++) {
-            Object element = list.get(i);
+            Object element = list.elementAt(i);
             if (potentialEntry == element) {
                 return i;
             }


### PR DESCRIPTION
Fix J2ME compat issue in https://github.com/dimagi/javarosa/pull/208/
`Vector.get` -> `Vector.elementAt`