### PR TITLE
2.25.2 hotfix: Revert dispatch on datetime in unpack

### DIFF
--- a/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -4,7 +4,6 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.condition.pivot.UnpivotableExpressionException;
 import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.DateData;
-import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
@@ -254,8 +253,6 @@ public class XPathPathExpr extends XPathExpression {
         } else if (val instanceof SelectMultiData) {
             return (new XFormAnswerDataSerializer()).serializeAnswerData(val);
         } else if (val instanceof DateData) {
-            return val.getValue();
-        } else if (val instanceof DateTimeData) {
             return val.getValue();
         } else if (val instanceof BooleanData) {
             return val.getValue();


### PR DESCRIPTION
Fix issue where a case entry's date_modified attribute value doesn't have time information. Turns out since our current form serialization technique doesn't store type info, dispatching on `DateTimeData` wasn't a good thing to do.

I've fixed form serialization in 2.26 to keep type info, so the change this PR is reverting can be left in master.

Bug originates from https://github.com/dimagi/javarosa/pull/195, which I made thinking it would fix the issues addressed in the 2.24.2 hotfix, but it actually didn't. Hence we can revert the changes safely.

Ticket: http://manage.dimagi.com/default.asp?190661