### PR TITLE
Distance between empty locations

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/data/GeoPointData.java
+++ b/core/src/main/java/org/javarosa/core/model/data/GeoPointData.java
@@ -116,6 +116,10 @@ public class GeoPointData implements IAnswerData {
         double[] ret = new double[4];
 
         Vector<String> choices = DateUtils.split(data.value, " ", true);
+        if (choices.size() < 2) {
+            throw new IllegalArgumentException("Fewer than two coordinates provided");
+        }
+
         int i = 0;
         for (String s : choices) {
             double d = Double.parseDouble(s);

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -1466,7 +1466,7 @@ public class XPathFuncExpr extends XPathExpression {
         String unpackedFrom = (String) unpack(from);
         String unpackedTo = (String) unpack(to);
 
-        if (unpackedFrom == "" || unpackedFrom == null || unpackedTo == "" || unpackedTo == null) {
+        if (unpackedFrom == null || "".equals(unpackedFrom) || unpackedTo == null || "".equals(unpackedTo)) {
             return -1.0;
         }
 

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -1460,10 +1460,15 @@ public class XPathFuncExpr extends XPathExpression {
      * Returns the distance between two GeoPointData locations, in meters, given objects to unpack.
      * Ignores altitude and accuracy.
      * Note that the arguments can be strings.
+     * Returns -1 if one of the arguments is null or the empty string.
      */
     public static Double distance(Object from, Object to) {
         String unpackedFrom = (String) unpack(from);
         String unpackedTo = (String) unpack(to);
+
+        if (unpackedFrom == "" || unpackedFrom == null || unpackedTo == "" || unpackedTo == null) {
+            return -1.0;
+        }
 
         // Casting and uncasting seems strange but is consistent with the codebase
         GeoPointData castedFrom = new GeoPointData().cast(new UncastData(unpackedFrom));

--- a/core/src/test/java/org/javarosa/core/model/test/GeoPointTests.java
+++ b/core/src/test/java/org/javarosa/core/model/test/GeoPointTests.java
@@ -42,4 +42,14 @@ public class GeoPointTests {
         ExprEvalUtils.assertAlmostEqualsXpathEval(
                 4127316.0, 1.0, "distance(/data/new_york, /data/san_francisco)", geopointEvalCtx);
     }
+
+    @Test
+    public void testDistanceFunctionBetweenEmptyPoints() throws XPathSyntaxException {
+        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is 0",
+                0.0, "distance(/data/new_york, /data/empty)", geopointEvalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is 0",
+                0.0, "/data/empty, /data/new_york)", geopointEvalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is 0",
+                0.0, "/data/empty, /data/empty)", geopointEvalCtx);
+    }
 }

--- a/core/src/test/java/org/javarosa/core/model/test/GeoPointTests.java
+++ b/core/src/test/java/org/javarosa/core/model/test/GeoPointTests.java
@@ -45,11 +45,11 @@ public class GeoPointTests {
 
     @Test
     public void testDistanceFunctionBetweenEmptyPoints() throws XPathSyntaxException {
-        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is 0",
-                0.0, "distance(/data/new_york, /data/empty)", geopointEvalCtx);
-        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is 0",
-                0.0, "/data/empty, /data/new_york)", geopointEvalCtx);
-        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is 0",
-                0.0, "/data/empty, /data/empty)", geopointEvalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is -1",
+                -1.0, "distance(/data/new_york, /data/empty)", geopointEvalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is -1",
+                -1.0, "distance(/data/empty, /data/new_york)", geopointEvalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("Make sure the distance from a point to an empty string is -1",
+                -1.0, "distance(/data/empty, /data/empty)", geopointEvalCtx);
     }
 }

--- a/core/src/test/resources/geopoint_tests.xml
+++ b/core/src/test/resources/geopoint_tests.xml
@@ -14,6 +14,7 @@
                     <random_geopoint>5.1111 23.23111</random_geopoint>
                     <new_york>40.7 -74.0 95 0</new_york>
                     <san_francisco>37.8 -122.4 16 0</san_francisco>
+                    <empty></empty>
                 </data>
             </instance>
 


### PR DESCRIPTION
Specification of distance function changed to return -1 when either argument is an empty string (or null). 

Previously, an exception would be thrown if an argument was null, and the location (0, 0, 0, 0) would be used for the empty string.