### PR TITLE
J2ME Compatibility for deserialziation exceptions

### DIFF
--- a/core/src/main/java/org/javarosa/core/util/externalizable/DeserializationException.java
+++ b/core/src/main/java/org/javarosa/core/util/externalizable/DeserializationException.java
@@ -13,6 +13,11 @@ public class DeserializationException extends Exception {
     }
 
     public DeserializationException(String message, Throwable cause) {
+        //#if polish.cldc
+        //# super(cause.getMessage() + ": " + message);
+        //#else
         super(message, cause);
+        //#endif
+
     }
 }


### PR DESCRIPTION
Permit setting throwable sources on deserializations when available on the current platform

Fix for https://github.com/dimagi/javarosa/pull/232 on j2me