### PR TITLE
override SelectChoice .equals() method to produce correct functionali…

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/SelectChoice.java
+++ b/core/src/main/java/org/javarosa/core/model/SelectChoice.java
@@ -121,4 +121,46 @@ public class SelectChoice implements Externalizable, Localizable {
     public void setTextID(String textID) {
         this.textID = textID;
     }
+
+    @Override
+    public int hashCode() {
+        int result;
+        result = textID != null ? textID.hashCode() : 0;
+        result = 31 * result + value.hashCode();
+        result = 31 * result + index;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof SelectChoice)) {
+            return false;
+        }
+
+        SelectChoice otherChoice = (SelectChoice)obj;
+
+        String otherTextID = otherChoice.getTextID();
+        if (otherTextID == null) {
+            if (this.textID != null) {
+                return false;
+            }
+        }
+        else if (!otherChoice.getTextID().equals(this.textID)) {
+            return false;
+        }
+
+        if (!otherChoice.getValue().equals(this.value)) {
+            return false;
+        }
+
+        if (otherChoice.getIndex() != this.index) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/core/src/main/java/org/javarosa/core/model/SelectChoice.java
+++ b/core/src/main/java/org/javarosa/core/model/SelectChoice.java
@@ -79,6 +79,9 @@ public class SelectChoice implements Externalizable, Localizable {
         return index;
     }
 
+    public boolean isLocalizable() {
+        return this.isLocalizable;
+    }
 
     public void localeChanged(String locale, Localizer localizer) {
 //        if (captionLocalizable) {
@@ -126,8 +129,10 @@ public class SelectChoice implements Externalizable, Localizable {
     public int hashCode() {
         int result;
         result = textID != null ? textID.hashCode() : 0;
-        result = 31 * result + value.hashCode();
-        result = 31 * result + index;
+        result = result ^ value.hashCode();
+        result = result ^ index;
+        result = result ^ (isLocalizable ? 1 : 0);
+        result = result ^ (labelInnerText != null ? labelInnerText.hashCode() : 0);
         return result;
     }
 
@@ -149,7 +154,7 @@ public class SelectChoice implements Externalizable, Localizable {
                 return false;
             }
         }
-        else if (!otherChoice.getTextID().equals(this.textID)) {
+        else if (!otherTextID.equals(this.textID)) {
             return false;
         }
 
@@ -158,6 +163,20 @@ public class SelectChoice implements Externalizable, Localizable {
         }
 
         if (otherChoice.getIndex() != this.index) {
+            return false;
+        }
+
+        if (otherChoice.isLocalizable() != this.isLocalizable) {
+            return false;
+        }
+
+        String otherLabelText = otherChoice.getLabelInnerText();
+        if (otherLabelText == null) {
+            if (this.labelInnerText != null) {
+                return false;
+            }
+        }
+        else if (!otherLabelText.equals(this.labelInnerText)) {
             return false;
         }
 


### PR DESCRIPTION
Fix for: http://manage.dimagi.com/default.asp?208770, which was introduced by https://github.com/dimagi/commcare-odk/pull/762. 

The issue as far as I can tell is this -- What is actually causing the user to be unable to select any options from the drop-down is that the code goes into an infinite loop when you view that question. The cause of that infinite loop is: FormEntryPrompt.selectChoicesAreUnchanged() checks for equality of the 2 SelectChoice vectors. In the case described in the ticket, selectChoicesAreUnchanged() is returning false, when it should be returning true, because .equals() on individual SelectChoices that are semantically equivalent is returning false. This is then causing a new form entry prompt to be added to the view when it really shouldn't be, and triggering the same code path to be called again.. etc. 

The ticket notes that the problem only comes up for single select *lookup tables*. When I was testing this change, I must not have tested it with any lookup table select widgets; just a normal select widget. My best guess is that the SelectChoices for a lookup table are re-created each time they are populated, meaning that now 2 different objects are being compared with .equals() and failing. 

tl;dr -- the solution (I think) is to override .equals() for SelectChoice. But I'm not sure if I'm doing it correctly, in terms of which fields should be included, and also if the corresponding hashCode() function is sufficient. 