### PR TITLE
fix bug in deserialization of DateData

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/data/DateData.java
+++ b/core/src/main/java/org/javarosa/core/model/data/DateData.java
@@ -82,8 +82,8 @@ public class DateData implements IAnswerData {
      * @see org.javarosa.core.services.storage.utilities.Externalizable#readExternal(java.io.DataInputStream)
      */
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        init();
         setValue(ExtUtil.readDate(in));
+        init();
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
mis-ordered calls in `readExternal` cause a NPE when DateDatas are deserialized. This particular situation likely never actually comes up, for reasons Clayton explained and I did not really follow well enough to repeat here... But I came across it in writing a test, and seems good to fix either way.