### PR TITLE
Make position(empty_ref) throw XPathTypeMismatchException

### DIFF
--- a/core/src/main/java/org/javarosa/xpath/XPathException.java
+++ b/core/src/main/java/org/javarosa/xpath/XPathException.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2009 JavaRosa
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.javarosa.xpath;
 
 public class XPathException extends RuntimeException {

--- a/core/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
+++ b/core/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
@@ -29,7 +29,7 @@ import java.util.Vector;
 public class XPathLazyNodeset extends XPathNodeset {
 
     Boolean evaluated = Boolean.FALSE;
-    TreeReference unExpandedRef;
+    private TreeReference unExpandedRef;
 
     /**
      * Construct an XPath nodeset.
@@ -137,5 +137,8 @@ public class XPathLazyNodeset extends XPathNodeset {
     protected String nodeContents() {
         performEvaluation();
         return super.nodeContents();
+    }
+    public String getUnexpandedRefString() {
+        return unExpandedRef.toString();
     }
 }

--- a/core/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
+++ b/core/src/test/java/org/javarosa/xpath/expr/test/XPathFuncExprTest.java
@@ -1,8 +1,15 @@
 package org.javarosa.xpath.expr.test;
 
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.test.FormParseInit;
+import org.javarosa.form.api.FormEntryController;
 import org.javarosa.test_utils.ExprEvalUtils;
 import org.javarosa.xpath.XPathException;
+import org.javarosa.xpath.XPathTypeMismatchException;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -21,5 +28,25 @@ public class XPathFuncExprTest {
 
         // out of bounds selection should raise an XPathException
         ExprEvalUtils.testEval("selected-at('hello there', 2)", instance, null, new XPathException());
+    }
+
+    /**
+     * Test that `position(some_ref)` throws a XPathTypeMismatchException when
+     * some_ref points to an empty nodeset
+     */
+    @Test
+    public void testOutOfBoundsPosition() throws XPathSyntaxException {
+        FormParseInit fpi = new FormParseInit("/xform_tests/test_position_with_ref.xml");
+        FormEntryController fec = fpi.getFormEntryController();
+        fpi.getFormDef().initialize(true, null);
+        fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+
+        try {
+            do {
+            } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
+        } catch (XPathTypeMismatchException e) {
+            return;
+        }
+        Assert.fail("form entry should fail on bad `position` usage before getting here");
     }
 }

--- a/core/src/test/resources/xform_tests/test_position_with_ref.xml
+++ b/core/src/test/resources/xform_tests/test_position_with_ref.xml
@@ -1,0 +1,39 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:jr="http://openrosa.org/javarosa"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Tests position(ref) failures</h:title>
+        <model>
+            <instance>
+                <data name="position failure"
+                      uiVersion="1"
+                      version="1"
+                      xmlns="http://openrosa.org/formdesigner/313BF9C4-9DF3-4B92-A111-1AB7306EA8CA">
+                    <how_many/>
+                    <animals jr:template="">
+                        <id_num/>
+                        <zoos jr:template="">
+                            <id_num/>
+                        </zoos>
+                    </animals>
+                </data>
+            </instance>
+
+            <bind nodeset="/data/how_many" type="xsd:int"/>
+            <bind calculate="position(/data/animals/zoos) + 1" nodeset="/data/animals/id_num"/>
+            <bind nodeset="/data/animals"/>
+            <setvalue event="xforms-ready" ref="/data/how_many" value="4"/>
+        </model>
+    </h:head>
+    <h:body>
+        <group>
+            <repeat nodeset="/data/animals" jr:count="/data/how_many" jr:noAddRemove="true()">
+                <group>
+                    <repeat nodeset="/data/animals/zoos" jr:count="/data/how_many"
+                            jr:noAddRemove="true()">
+                    </repeat>
+                </group>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Usages of `position(some_empty_ref)` were crashing CommCare with an `ArrayIndexOutOfBoundsException`.

Catch such errors and rethrow a more helpful `XPathTypeMismatchException` that can be caught further up and shown to the user. 

There are hundreds of such crashes on ACRA, here is one as an example: 
https://commcare-acralyzer.cloudant.com/acralyzer/_design/acralyzer/index.html#/reports-browser/commcare-odk/bug/9f16e2fc08448dd30dd3e3d5f4acea97