### PR TITLE
Trigger lookaheads correctly in model iteration

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -593,12 +593,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             triggerablesInOrder = false;
 
             for (TreeReference trigger : t.getTriggers()) {
-                t.updateStopContextualizingAt(trigger);
-                TreeReference plainTrigger = trigger.removePredicates();
-                if (!triggerIndex.containsKey(plainTrigger)) {
-                    triggerIndex.put(plainTrigger.clone(), new Vector<Triggerable>());
+                TreeReference predicatelessTrigger = t.widenContextToAndClearPredicates(trigger);
+                if (!triggerIndex.containsKey(predicatelessTrigger)) {
+                    triggerIndex.put(predicatelessTrigger.clone(), new Vector<Triggerable>());
                 }
-                Vector<Triggerable> triggered = triggerIndex.get(plainTrigger);
+                Vector<Triggerable> triggered = triggerIndex.get(predicatelessTrigger);
                 if (!triggered.contains(t)) {
                     triggered.addElement(t);
                 }

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -204,7 +204,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     public IFormElement getChild(int i) {
         if (i < this.children.size())
-            return (IFormElement)this.children.elementAt(i);
+            return this.children.elementAt(i);
 
         throw new ArrayIndexOutOfBoundsException(
                 "FormDef: invalid child index: " + i + " only "
@@ -228,9 +228,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * yet-to-be-created repeat node (similar to repeats that already exist)
      */
     public Vector explodeIndex(FormIndex index) {
-        Vector<Integer> indexes = new Vector();
-        Vector<Integer> multiplicities = new Vector();
-        Vector<IFormElement> elements = new Vector();
+        Vector<Integer> indexes = new Vector<Integer>();
+        Vector<Integer> multiplicities = new Vector<Integer>();
+        Vector<IFormElement> elements = new Vector<IFormElement>();
 
         collapseIndex(index, indexes, multiplicities, elements);
         return elements;
@@ -240,9 +240,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     // multiplicities)
 
     public TreeReference getChildInstanceRef(FormIndex index) {
-        Vector<Integer> indexes = new Vector();
-        Vector<Integer> multiplicities = new Vector();
-        Vector<IFormElement> elements = new Vector();
+        Vector<Integer> indexes = new Vector<Integer>();
+        Vector<Integer> multiplicities = new Vector<Integer>();
+        Vector<IFormElement> elements = new Vector<IFormElement>();
 
         collapseIndex(index, indexes, multiplicities, elements);
         return getChildInstanceRef(elements, multiplicities);
@@ -259,7 +259,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         }
 
         // get reference for target element
-        TreeReference ref = FormInstance.unpackReference(((IFormElement)elements.lastElement()).getBind()).clone();
+        TreeReference ref = FormInstance.unpackReference(elements.lastElement().getBind()).clone();
         for (int i = 0; i < ref.size(); i++) {
             //There has to be a better way to encapsulate this
             if (ref.getMultiplicity(i) != TreeReference.INDEX_ATTRIBUTE) {
@@ -578,7 +578,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             // the two), otherwise we can end up failing to trigger when the
             // ignored context exists and the used one doesn't
 
-            Triggerable existingTriggerable = (Triggerable)triggerables.elementAt(existingIx);
+            Triggerable existingTriggerable = triggerables.elementAt(existingIx);
 
             existingTriggerable.contextRef = existingTriggerable.contextRef.intersect(t.contextRef);
 
@@ -598,7 +598,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 if (!triggerIndex.containsKey(plainTrigger)) {
                     triggerIndex.put(plainTrigger.clone(), new Vector<Triggerable>());
                 }
-                Vector<Triggerable> triggered = (Vector<Triggerable>)triggerIndex.get(plainTrigger);
+                Vector<Triggerable> triggered = triggerIndex.get(plainTrigger);
                 if (!triggered.contains(t)) {
                     triggered.addElement(t);
                 }
@@ -652,13 +652,13 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
         Vector<Triggerable[]> partialOrdering = new Vector<Triggerable[]>();
         for (int i = 0; i < triggerables.size(); i++) {
-            Triggerable t = (Triggerable)triggerables.elementAt(i);
+            Triggerable t = triggerables.elementAt(i);
 
             Vector<Triggerable> deps = new Vector<Triggerable>();
             fillTriggeredElements(t, deps, false);
 
             for (int j = 0; j < deps.size(); j++) {
-                Triggerable u = (Triggerable)deps.elementAt(j);
+                Triggerable u = deps.elementAt(j);
                 Triggerable[] edge = {t, u};
                 partialOrdering.addElement(edge);
             }
@@ -676,7 +676,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 roots.addElement(vertices.elementAt(i));
             }
             for (int i = 0; i < partialOrdering.size(); i++) {
-                Triggerable[] edge = (Triggerable[])partialOrdering.elementAt(i);
+                Triggerable[] edge = partialOrdering.elementAt(i);
                 roots.removeElement(edge[1]);
             }
 
@@ -697,12 +697,12 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
             //remove root nodes and edges originating from them
             for (int i = 0; i < roots.size(); i++) {
-                Triggerable root = (Triggerable)roots.elementAt(i);
+                Triggerable root = roots.elementAt(i);
                 triggerables.addElement(root);
                 vertices.removeElement(root);
             }
             for (int i = partialOrdering.size() - 1; i >= 0; i--) {
-                Triggerable[] edge = (Triggerable[])partialOrdering.elementAt(i);
+                Triggerable[] edge = partialOrdering.elementAt(i);
                 if (roots.contains(edge[0]))
                     partialOrdering.removeElementAt(i);
             }
@@ -714,7 +714,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
         conditionRepeatTargetIndex = new Hashtable<TreeReference, Condition>();
         for (int i = 0; i < triggerables.size(); i++) {
-            Triggerable t = (Triggerable)triggerables.elementAt(i);
+            Triggerable t = triggerables.elementAt(i);
             if (t instanceof Condition) {
                 Vector targets = t.getTargets();
                 for (int j = 0; j < targets.size(); j++) {
@@ -861,8 +861,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             if (ref.hasPredicates()) {
                 predicatelessRef = ref.removePredicates();
             }
-            Vector<Triggerable> triggered =
-                    (Vector<Triggerable>)triggerIndex.get(predicatelessRef);
+            Vector<Triggerable> triggered = triggerIndex.get(predicatelessRef);
 
             if (triggered != null) {
                 //If so, walk all of these triggerables that we found
@@ -889,7 +888,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     public void enableDebugTraces() {
         if (!mDebugModeEnabled) {
             for (int i = 0; i < triggerables.size(); i++) {
-                Triggerable t = (Triggerable)triggerables.elementAt(i);
+                Triggerable t = triggerables.elementAt(i);
                 t.setDebug(true);
             }
 
@@ -906,7 +905,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     public void disableDebugTraces() {
         if (mDebugModeEnabled) {
             for (int i = 0; i < triggerables.size(); i++) {
-                Triggerable t = (Triggerable)triggerables.elementAt(i);
+                Triggerable t = triggerables.elementAt(i);
                 t.setDebug(false);
             }
             mDebugModeEnabled = false;
@@ -936,7 +935,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 new Hashtable<TreeReference, Hashtable<String, EvaluationTrace>>();
 
         for (int i = 0; i < triggerables.size(); i++) {
-            Triggerable t = (Triggerable)triggerables.elementAt(i);
+            Triggerable t = triggerables.elementAt(i);
 
             Hashtable<TreeReference, EvaluationTrace> triggerOutputs = t.getEvaluationTraces();
 
@@ -1046,7 +1045,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         // Update the list of triggerables that need to be evaluated.
         for (int i = 0; i < tv.size(); i++) {
             // NOTE PLM: tv may grow in size through iteration.
-            Triggerable t = (Triggerable)tv.elementAt(i);
+            Triggerable t = tv.elementAt(i);
             fillTriggeredElements(t, tv, isRepeatEntryInit);
         }
 
@@ -1054,10 +1053,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         // going to need to be addressed by this update.
         // 'triggerables' is topologically-ordered by dependencies, so evaluate
         // the triggerables in 'tv' in the order they appear in 'triggerables'
-        for (int i = 0; i < triggerables.size(); i++) {
-            Triggerable t = (Triggerable)triggerables.elementAt(i);
-            if (tv.contains(t)) {
-                evaluateTriggerable(t, anchorRef);
+        for (Triggerable triggerable : triggerables) {
+            if (tv.contains(triggerable)) {
+                evaluateTriggerable(triggerable, anchorRef);
             }
         }
     }
@@ -1067,24 +1065,19 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * against the anchor (the value that changed which triggered
      * recomputation)
      *
-     * @param t         The triggerable to be updated
+     * @param triggerable         The triggerable to be updated
      * @param anchorRef The reference to the value which was changed.
      */
-    private void evaluateTriggerable(Triggerable t, TreeReference anchorRef) {
+    private void evaluateTriggerable(Triggerable triggerable, TreeReference anchorRef) {
         // Contextualize the reference used by the triggerable against the anchor
-        TreeReference contextRef = t.contextualizeContext(anchorRef);
+        TreeReference contextRef = triggerable.contextualizeContext(anchorRef);
 
         // Now identify all of the fully qualified nodes which this triggerable
         // updates. (Multiple nodes can be updated by the same trigger)
-        Vector<TreeReference> v = exprEvalContext.expandReference(contextRef);
+        Vector<TreeReference> expandedReferences = exprEvalContext.expandReference(contextRef);
 
-        // Go through each one and evaluate the trigger expresion
-        for (int i = 0; i < v.size(); i++) {
-            try {
-                t.apply(mainInstance, exprEvalContext, v.elementAt(i), this);
-            } catch (RuntimeException e) {
-                throw e;
-            }
+        for (TreeReference treeReference : expandedReferences) {
+            triggerable.apply(mainInstance, exprEvalContext, treeReference, this);
         }
     }
 
@@ -1120,10 +1113,12 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         if (!ec.getFunctionHandlers().containsKey("jr:itext")) {
             final FormDef f = this;
             ec.addFunctionHandler(new IFunctionHandler() {
+                @Override
                 public String getName() {
                     return "jr:itext";
                 }
 
+                @Override
                 public Object eval(Object[] args, EvaluationContext ec) {
                     String textID = (String)args[0];
                     try {
@@ -1142,13 +1137,15 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                     }
                 }
 
+                @Override
                 public Vector getPrototypes() {
                     Class[] proto = {String.class};
-                    Vector v = new Vector();
+                    Vector<Class[]> v = new Vector<Class[]>();
                     v.addElement(proto);
                     return v;
                 }
 
+                @Override
                 public boolean rawArgs() {
                     return false;
                 }
@@ -1170,10 +1167,12 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         if (!ec.getFunctionHandlers().containsKey("jr:choice-name")) {
             final FormDef f = this;
             ec.addFunctionHandler(new IFunctionHandler() {
+                @Override
                 public String getName() {
                     return "jr:choice-name";
                 }
 
+                @Override
                 public Object eval(Object[] args, EvaluationContext ec) {
                     try {
                         String value = (String)args[0];
@@ -1211,13 +1210,15 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                     }
                 }
 
+                @Override
                 public Vector getPrototypes() {
                     Class[] proto = {String.class, String.class};
-                    Vector v = new Vector();
+                    Vector<Class[]> v = new Vector<Class[]>();
                     v.addElement(proto);
                     return v;
                 }
 
+                @Override
                 public boolean rawArgs() {
                     return false;
                 }
@@ -1378,13 +1379,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         this.preloader = preloads;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.javarosa.core.model.utils.Localizable#localeChanged(java.lang.String,
-     * org.javarosa.core.model.utils.Localizer)
-     */
+    @Override
     public void localeChanged(String locale, Localizer localizer) {
         for (Enumeration e = children.elements(); e.hasMoreElements(); ) {
             ((IFormElement)e.nextElement()).localeChanged(locale, localizer);
@@ -1550,7 +1545,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         Vector<Condition> conditions = new Vector<Condition>();
         Vector<Recalculate> recalcs = new Vector<Recalculate>();
         for (int i = 0; i < triggerables.size(); i++) {
-            Triggerable t = (Triggerable)triggerables.elementAt(i);
+            Triggerable t = triggerables.elementAt(i);
             if (t instanceof Condition) {
                 conditions.addElement((Condition)t);
             } else if (t instanceof Recalculate) {

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -647,9 +647,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      *                               triggers can't be laid out appropriately
      */
     public void finalizeTriggerables() throws IllegalStateException {
-        //DAGify the triggerables based on dependencies and sort them so that
-        //trigbles come only after the trigbles they depend on
-
         Vector<Triggerable[]> partialOrdering = new Vector<Triggerable[]>();
         buildPartialOrdering(partialOrdering);
 
@@ -690,11 +687,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     private static Vector<Triggerable> buildRootNodes(Vector<Triggerable> vertices,
                                                       Vector<Triggerable[]> partialOrdering) {
         Vector<Triggerable> roots = new Vector<Triggerable>();
-        for (int i = 0; i < vertices.size(); i++) {
-            roots.addElement(vertices.elementAt(i));
+        for (Triggerable vertex : vertices) {
+            roots.addElement(vertex);
         }
-        for (int i = 0; i < partialOrdering.size(); i++) {
-            Triggerable[] edge = partialOrdering.elementAt(i);
+        for (Triggerable[] edge : partialOrdering) {
+            edge[1].updateStopContextualizingAtFromDominator(edge[0]);
             roots.removeElement(edge[1]);
         }
         return roots;
@@ -1475,9 +1472,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      *
      * Requires that the instance has been set to a prototype of the instance that
      * should be used for deserialization.
-     *
-     * @param dis - the stream to read from.
      */
+    @Override
     public void readExternal(DataInputStream dis, PrototypeFactory pf) throws IOException, DeserializationException {
         setID(ExtUtil.readInt(dis));
         setName(ExtUtil.nullIfEmpty(ExtUtil.readString(dis)));
@@ -1543,10 +1539,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     /**
      * Writes the form definition object to the supplied stream.
-     *
-     * @param dos - the stream to write to.
-     * @throws IOException
      */
+    @Override
     public void writeExternal(DataOutputStream dos) throws IOException {
         ExtUtil.writeNumeric(dos, getID());
         ExtUtil.writeString(dos, ExtUtil.emptyIfNull(getName()));

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1079,7 +1079,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      */
     private void evaluateTriggerable(Triggerable triggerable, TreeReference anchorRef) {
         // Contextualize the reference used by the triggerable against the anchor
-        TreeReference contextRef = triggerable.contextualizeContext(anchorRef);
+        TreeReference contextRef = triggerable.narrowContextBy(anchorRef);
 
         // Now identify all of the fully qualified nodes which this triggerable
         // updates. (Multiple nodes can be updated by the same trigger)

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -593,10 +593,12 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             triggerablesInOrder = false;
 
             for (TreeReference trigger : t.getTriggers()) {
-                if (!triggerIndex.containsKey(trigger)) {
-                    triggerIndex.put(trigger.clone(), new Vector<Triggerable>());
+                t.updateStopContextualizingAt(trigger);
+                TreeReference plainTrigger = trigger.removePredicates();
+                if (!triggerIndex.containsKey(plainTrigger)) {
+                    triggerIndex.put(plainTrigger.clone(), new Vector<Triggerable>());
                 }
-                Vector<Triggerable> triggered = (Vector<Triggerable>)triggerIndex.get(trigger);
+                Vector<Triggerable> triggered = (Vector<Triggerable>)triggerIndex.get(plainTrigger);
                 if (!triggered.contains(t)) {
                     triggered.addElement(t);
                 }
@@ -1070,7 +1072,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      */
     private void evaluateTriggerable(Triggerable t, TreeReference anchorRef) {
         // Contextualize the reference used by the triggerable against the anchor
-        TreeReference contextRef = t.contextRef.contextualize(anchorRef);
+        TreeReference contextRef = t.contextualizeContext(anchorRef);
 
         // Now identify all of the fully qualified nodes which this triggerable
         // updates. (Multiple nodes can be updated by the same trigger)

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -419,7 +419,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     public boolean isRepeatRelevant(TreeReference repeatRef) {
         boolean relev = true;
 
-        Condition c = (Condition)conditionRepeatTargetIndex.get(repeatRef.genericize());
+        Condition c = conditionRepeatTargetIndex.get(repeatRef.genericize());
         if (c != null) {
             relev = c.evalBool(mainInstance, new EvaluationContext(exprEvalContext, repeatRef));
         }
@@ -643,7 +643,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * the appropriate ordering and dependencies to ensure the conditions will be evaluated
      * in the appropriate orders.
      *
-     * @throws IllegalStateException - If the trigger ordering contains an illegal cycle and the
+     * @throws IllegalStateException If the trigger ordering contains an illegal cycle and the
      *                               triggers can't be laid out appropriately
      */
     public void finalizeTriggerables() throws IllegalStateException {
@@ -651,81 +651,94 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         //trigbles come only after the trigbles they depend on
 
         Vector<Triggerable[]> partialOrdering = new Vector<Triggerable[]>();
-        for (int i = 0; i < triggerables.size(); i++) {
-            Triggerable t = triggerables.elementAt(i);
-
-            Vector<Triggerable> deps = new Vector<Triggerable>();
-            fillTriggeredElements(t, deps, false);
-
-            for (int j = 0; j < deps.size(); j++) {
-                Triggerable u = deps.elementAt(j);
-                Triggerable[] edge = {t, u};
-                partialOrdering.addElement(edge);
-            }
-        }
+        buildPartialOrdering(partialOrdering);
 
         Vector<Triggerable> vertices = new Vector<Triggerable>();
-        for (int i = 0; i < triggerables.size(); i++)
-            vertices.addElement(triggerables.elementAt(i));
+        for (Triggerable triggerable : triggerables) {
+            vertices.addElement(triggerable);
+        }
         triggerables.removeAllElements();
 
         while (vertices.size() > 0) {
-            //determine root nodes
-            Vector<Triggerable> roots = new Vector<Triggerable>();
-            for (int i = 0; i < vertices.size(); i++) {
-                roots.addElement(vertices.elementAt(i));
-            }
-            for (int i = 0; i < partialOrdering.size(); i++) {
-                Triggerable[] edge = partialOrdering.elementAt(i);
-                roots.removeElement(edge[1]);
-            }
+            Vector<Triggerable> roots = buildRootNodes(vertices, partialOrdering);
 
-            //if no root nodes while graph still has nodes, graph has cycles
             if (roots.size() == 0) {
-                String hints = "";
-                for (Triggerable t : vertices) {
-                    for (TreeReference r : t.getTargets()) {
-                        hints += "\n" + r.toString(true);
-                    }
-                }
-                String message = "Cycle detected in form's relevant and calculation logic!";
-                if (!hints.equals("")) {
-                    message += "\nThe following nodes are likely involved in the loop:" + hints;
-                }
-                throw new IllegalStateException(message);
+                // if no root nodes while graph still has nodes, graph has cycles
+                throwGraphCyclesException(vertices);
             }
 
-            //remove root nodes and edges originating from them
-            for (int i = 0; i < roots.size(); i++) {
-                Triggerable root = roots.elementAt(i);
-                triggerables.addElement(root);
-                vertices.removeElement(root);
-            }
-            for (int i = partialOrdering.size() - 1; i >= 0; i--) {
-                Triggerable[] edge = partialOrdering.elementAt(i);
-                if (roots.contains(edge[0]))
-                    partialOrdering.removeElementAt(i);
-            }
+            setOrderOfTriggerable(roots, vertices, partialOrdering);
         }
 
         triggerablesInOrder = true;
 
-        //build the condition index for repeatable nodes
+        buildConditionRepeatTargetIndex();
+    }
 
+    private void buildPartialOrdering(Vector<Triggerable[]> partialOrdering) {
+        for (Triggerable t : triggerables) {
+            Vector<Triggerable> deps = new Vector<Triggerable>();
+            fillTriggeredElements(t, deps, false);
+
+            for (Triggerable u : deps) {
+                Triggerable[] edge = {t, u};
+                partialOrdering.addElement(edge);
+            }
+        }
+    }
+
+    private static Vector<Triggerable> buildRootNodes(Vector<Triggerable> vertices,
+                                                      Vector<Triggerable[]> partialOrdering) {
+        Vector<Triggerable> roots = new Vector<Triggerable>();
+        for (int i = 0; i < vertices.size(); i++) {
+            roots.addElement(vertices.elementAt(i));
+        }
+        for (int i = 0; i < partialOrdering.size(); i++) {
+            Triggerable[] edge = partialOrdering.elementAt(i);
+            roots.removeElement(edge[1]);
+        }
+        return roots;
+    }
+
+    private void throwGraphCyclesException(Vector<Triggerable> vertices) {
+        String hints = "";
+        for (Triggerable t : vertices) {
+            for (TreeReference r : t.getTargets()) {
+                hints += "\n" + r.toString(true);
+            }
+        }
+        String message = "Cycle detected in form's relevant and calculation logic!";
+        if (!hints.equals("")) {
+            message += "\nThe following nodes are likely involved in the loop:" + hints;
+        }
+        throw new IllegalStateException(message);
+    }
+
+    private void setOrderOfTriggerable(Vector<Triggerable> roots,
+                                       Vector<Triggerable> vertices,
+                                       Vector<Triggerable[]> partialOrdering) {
+        for (Triggerable root : roots) {
+            triggerables.addElement(root);
+            vertices.removeElement(root);
+        }
+        for (int i = partialOrdering.size() - 1; i >= 0; i--) {
+            Triggerable[] edge = partialOrdering.elementAt(i);
+            if (roots.contains(edge[0]))
+                partialOrdering.removeElementAt(i);
+        }
+    }
+
+    private void buildConditionRepeatTargetIndex() {
         conditionRepeatTargetIndex = new Hashtable<TreeReference, Condition>();
-        for (int i = 0; i < triggerables.size(); i++) {
-            Triggerable t = triggerables.elementAt(i);
+        for (Triggerable t : triggerables) {
             if (t instanceof Condition) {
-                Vector targets = t.getTargets();
-                for (int j = 0; j < targets.size(); j++) {
-                    TreeReference target = (TreeReference)targets.elementAt(j);
+                for (TreeReference target : t.getTargets()) {
                     if (mainInstance.getTemplate(target) != null) {
                         conditionRepeatTargetIndex.put(target, (Condition)t);
                     }
                 }
             }
         }
-
     }
 
     /**

--- a/core/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -289,6 +289,14 @@ public abstract class Triggerable implements Externalizable {
         }
     }
 
+    public void updateStopContextualizingAtFromDominator(Triggerable dominator) {
+        if (dominator.stopContextualizingAt != -1 &&
+                (stopContextualizingAt == -1 || dominator.stopContextualizingAt < stopContextualizingAt) &&
+                dominator.contextRef.intersect(contextRef).size() >= dominator.stopContextualizingAt) {
+            stopContextualizingAt = dominator.stopContextualizingAt;
+        }
+    }
+
     private int smallestIntersectingLevelWithPred(TreeReference refInExpr) {
         TreeReference intersectionRef = contextRef.intersect(refInExpr.removePredicates());
         for (int refLevel = 0; refLevel < Math.min(refInExpr.size(), intersectionRef.size()); refLevel++) {

--- a/core/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -142,13 +142,11 @@ public abstract class Triggerable implements Externalizable {
 
         Object result = eval(instance, triggerEval);
 
-        for (int i = 0; i < targets.size(); i++) {
-            TreeReference targetRef =
-                    ((TreeReference)targets.elementAt(i)).contextualize(ec.getContextRef());
-            Vector v = ec.expandReference(targetRef);
+        for (TreeReference baseTargetRef : targets) {
+            TreeReference targetRef = baseTargetRef.contextualize(ec.getContextRef());
+            Vector<TreeReference> expandedReferences = ec.expandReference(targetRef);
 
-            for (int j = 0; j < v.size(); j++) {
-                TreeReference affectedRef = (TreeReference)v.elementAt(j);
+            for (TreeReference affectedRef : expandedReferences) {
                 if (mIsDebugOn) {
                     mTriggerDebugs.put(affectedRef, triggerEval.getEvaluationTrace());
                 }
@@ -186,7 +184,7 @@ public abstract class Triggerable implements Externalizable {
         // construct absolute references by anchoring against the original context reference
         Vector<TreeReference> absTriggers = new Vector<TreeReference>();
         for (int i = 0; i < relTriggers.size(); i++) {
-            TreeReference ref = ((TreeReference)relTriggers.elementAt(i)).anchor(originalContextRef);
+            TreeReference ref = relTriggers.elementAt(i).anchor(originalContextRef);
             absTriggers.addElement(ref);
         }
         return absTriggers;
@@ -263,7 +261,7 @@ public abstract class Triggerable implements Externalizable {
     public String toString() {
         StringBuffer sb = new StringBuffer();
         for (int i = 0; i < targets.size(); i++) {
-            sb.append(((TreeReference)targets.elementAt(i)).toString());
+            sb.append(targets.elementAt(i).toString());
             if (i < targets.size() - 1)
                 sb.append(",");
         }

--- a/core/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -292,11 +292,11 @@ public abstract class Triggerable implements Externalizable {
     }
 
     private int smallestIntersectingLevelWithPred(TreeReference refInExpr) {
-        TreeReference intersectionRef = contextRef.intersect(refInExpr);
-        for (int refLevel = 0; refLevel <= intersectionRef.size(); refLevel++) {
+        TreeReference intersectionRef = contextRef.intersect(refInExpr.removePredicates());
+        for (int refLevel = 0; refLevel < Math.min(refInExpr.size(), intersectionRef.size()); refLevel++) {
             Vector<XPathExpression> predicates = refInExpr.getPredicate(refLevel);
             if (predicates != null && predicates.size() > 0) {
-                return refLevel - 1;
+                return refLevel;
             }
         }
         return -1;

--- a/core/src/main/java/org/javarosa/core/model/condition/Triggerable.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/Triggerable.java
@@ -277,7 +277,7 @@ public abstract class Triggerable implements Externalizable {
         }
     }
 
-    public void updateStopContextualizingAt(TreeReference refInExpr) {
+    public TreeReference widenContextToAndClearPredicates(TreeReference refInExpr) {
         int smallestIntersectionForRef = smallestIntersectingLevelWithPred(refInExpr);
 
         if (smallestIntersectionForRef != -1) {
@@ -287,6 +287,7 @@ public abstract class Triggerable implements Externalizable {
                 stopContextualizingAt = Math.min(stopContextualizingAt, smallestIntersectionForRef);
             }
         }
+        return refInExpr.removePredicates();
     }
 
     public void updateStopContextualizingAtFromDominator(Triggerable dominator) {

--- a/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeReference.java
@@ -465,8 +465,12 @@ public class TreeReference implements Externalizable {
      * multiplicity set to unbounded.
      */
     public TreeReference genericize() {
+        return genericizeAfter(0);
+    }
+
+    public TreeReference genericizeAfter(int levelToStartGenericizing) {
         TreeReference genericRef = clone();
-        for (int i = 0; i < genericRef.size(); i++) {
+        for (int i = levelToStartGenericizing; i < genericRef.size(); i++) {
             // TODO: It's not super clear whether template refs should get
             // genericized or not
             if (genericRef.getMultiplicity(i) > -1 ||

--- a/core/src/main/java/org/javarosa/xpath/XPathConditional.java
+++ b/core/src/main/java/org/javarosa/xpath/XPathConditional.java
@@ -84,8 +84,9 @@ public class XPathConditional implements IConditionExpr {
      * for retriggering the expression's evaluation if any of these references
      * value or relevancy calculations once.
      */
+    @Override
     public Vector<TreeReference> getExprsTriggers(TreeReference originalContextRef) {
-        Vector triggers = new Vector();
+        Vector<TreeReference> triggers = new Vector<TreeReference>();
         getExprsTriggersAccumulator(expr, triggers, null, originalContextRef);
         return triggers;
     }
@@ -135,12 +136,6 @@ public class XPathConditional implements IConditionExpr {
                     getExprsTriggersAccumulator(predicate, triggers,
                             predicateContext, originalContextRef);
                 }
-            }
-
-            // TODO: It's possible we should just handle this the same way as
-            // "genericize". Not entirely clear.
-            if (contextualized.hasPredicates()) {
-                contextualized = contextualized.removePredicates();
             }
             if (!triggers.contains(contextualized)) {
                 triggers.addElement(contextualized);

--- a/core/src/main/java/org/javarosa/xpath/XPathConditional.java
+++ b/core/src/main/java/org/javarosa/xpath/XPathConditional.java
@@ -171,7 +171,7 @@ public class XPathConditional implements IConditionExpr {
 
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         expr = (XPathExpression)ExtUtil.read(in, new ExtWrapTagged(), pf);
-        hasNow = (boolean)ExtUtil.readBool(in);
+        hasNow = ExtUtil.readBool(in);
     }
 
     public void writeExternal(DataOutputStream out) throws IOException {

--- a/core/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
+++ b/core/src/main/java/org/javarosa/xpath/XPathLazyNodeset.java
@@ -75,10 +75,8 @@ public class XPathLazyNodeset extends XPathNodeset {
             //multiplicites) we should be able to do this without doing the expansion
 
             //first, see if this treeref is usable without expansion
-            int size = unExpandedRef.size();
             boolean safe = true;
-
-            for (int i = 0; i < size; ++i) {
+            for (int i = 0; i < unExpandedRef.size(); ++i) {
                 //We can't evaluated any predicates for sure
                 if (unExpandedRef.getPredicate(i) != null) {
                     safe = false;
@@ -95,8 +93,8 @@ public class XPathLazyNodeset extends XPathNodeset {
                 return super.unpack();
             }
 
-            //TOOD: Evaluate error fallbacks, here. I don't know whether this handles the 0 case
-            //the same way, although invalid multiplicities should be fine.
+            // TODO: Evaluate error fallbacks, here. I don't know whether this handles the 0 case
+            // the same way, although invalid multiplicities should be fine.
             try {
                 //TODO: This doesn't handle templated nodes (repeats which may exist in the future)
                 //figure out if we can roll that in easily. For now the catch handles it

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -14,6 +14,7 @@ import org.javarosa.core.test.FormParseInit;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.test_utils.ExprEvalUtils;
+import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -311,8 +312,17 @@ public class FormDefTest {
         fec.getNextIndex(fec.getModel().getFormIndex(), true);
     }
 
+    /**
+     * Android-level form save on complete used to run through all
+     * triggerables.  Disabling this, for performance reasons, exposed a bug
+     * were triggerables that fire on repeat inserts and have expressions that
+     * reference future (to be inserted) repeat entries never get re-fired due
+     * to over contextualization. This has been fixed by generalizing the
+     * triggerable context where path predicates are present for intersecting
+     * references in the triggerable expression.
+     */
     @Test
-    public void testModelIterationLookahead() throws Exception {
+    public void testModelIterationLookahead() throws XPathSyntaxException {
         FormParseInit fpi = new FormParseInit("/xform_tests/model_iteration_lookahead.xml");
         FormEntryController fec = fpi.getFormEntryController();
         fpi.getFormDef().initialize(true, null);

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -322,8 +322,8 @@ public class FormDefTest {
         } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
         EvaluationContext evalCtx = fpi.getFormDef().getEvaluationContext();
         ExprEvalUtils.assertEqualsXpathEval("",
-                "20", "/data/myiterator/iterator[1]/target_value", evalCtx);
+                "20", "/data/myiterator/iterator[1]/target_value/value", evalCtx);
         ExprEvalUtils.assertEqualsXpathEval("",
-                100.0, "/data/myiterator/iterator[1]/relevancy_depending_on_future", evalCtx);
+                "20", "/data/myiterator/iterator[1]/target_value/value_again", evalCtx);
     }
 }

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -311,4 +311,17 @@ public class FormDefTest {
         fec.getNextIndex(fec.getModel().getFormIndex(), true);
     }
 
+    @Test
+    public void testModelIterationLookahead() throws Exception {
+        FormParseInit fpi = new FormParseInit("/xform_tests/model_iteration_lookahead.xml");
+        FormEntryController fec = fpi.getFormEntryController();
+        fpi.getFormDef().initialize(true, null);
+        fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+
+        do {
+        } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
+        EvaluationContext evalCtx = fpi.getFormDef().getEvaluationContext();
+        ExprEvalUtils.assertEqualsXpathEval("",
+                "20", "/data/myiterator/iterator[1]/target_value", evalCtx);
+    }
 }

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -322,8 +322,8 @@ public class FormDefTest {
         } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
         EvaluationContext evalCtx = fpi.getFormDef().getEvaluationContext();
         ExprEvalUtils.assertEqualsXpathEval("",
-                "20", "/data/myiterator/iterator[1]/target_value/value", evalCtx);
+                "20", "/data/myiterator/iterator[1]/target_value", evalCtx);
         ExprEvalUtils.assertEqualsXpathEval("",
-                "20", "/data/myiterator/iterator[1]/target_value/value_again", evalCtx);
+                100.0, "/data/myiterator/iterator[1]/relevancy_depending_on_future", evalCtx);
     }
 }

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -323,5 +323,7 @@ public class FormDefTest {
         EvaluationContext evalCtx = fpi.getFormDef().getEvaluationContext();
         ExprEvalUtils.assertEqualsXpathEval("",
                 "20", "/data/myiterator/iterator[1]/target_value", evalCtx);
+        ExprEvalUtils.assertEqualsXpathEval("",
+                100.0, "/data/myiterator/iterator[1]/relevancy_depending_on_future", evalCtx);
     }
 }

--- a/core/src/test/resources/xform_tests/model_iteration_lookahead.xml
+++ b/core/src/test/resources/xform_tests/model_iteration_lookahead.xml
@@ -29,10 +29,8 @@
                             <question/>
                             <value/>
                             <target/>
-                            <target_value>
-                                <value/>
-                                <value_again/>
-                            </target_value>
+                            <target_value/>
+                            <relevancy_depending_on_future/>
                         </iterator>
                     </myiterator>
 
@@ -45,28 +43,15 @@
                   nodeset="/data/myiterator/iterator/value"/>
             <bind calculate="/data/itemdata/item[@id=current()/../@id]/@target"
                   nodeset="/data/myiterator/iterator/target"/>
-            <bind calculate="/data/myiterator/iterator[@id = current()/../../target]/value"
-                  nodeset="/data/myiterator/iterator/target_value/value"/>
+            <bind calculate="/data/myiterator/iterator[@id = current()/../target]/value"
+                  nodeset="/data/myiterator/iterator/target_value"/>
 
             <bind calculate="join(' ', /data/itemdata/item/@id)"
                   nodeset="/data/myiterator/elements"/>
 
-            <!--
-            Tests the propagation of trigger context widening:
-            since the nodeset and a subexpression in the calculate share a
-            prefix path and there are predicates in that path, when this
-            calculate is triggered it has to widden its context for all path
-            steps including and after the occurrence of that predicate. Tricky
-            part is if the triggering occurs due to an earlier, dominating
-            calculate being fired, which also has had widening applied to it,
-            we must take the minimum of the two.
-
-            If this didn't work correctly, you might expect the
-            /data/myiterator/iterator/target_value/value ref to not reflect the
-            most up-to-date value
-            -->
-            <bind calculate="/data/myiterator/iterator/target_value[true()]/value"
-                  nodeset="/data/myiterator/iterator/target_value/value_again" />
+            <bind calculate="100"
+                  nodeset="/data/myiterator/iterator/relevancy_depending_on_future"
+                  relevant="/data/myiterator/iterator/target_value != ''"/>
 
             <setvalue event="jr-insert"
                       ref="/data/myiterator/iterator/@index"

--- a/core/src/test/resources/xform_tests/model_iteration_lookahead.xml
+++ b/core/src/test/resources/xform_tests/model_iteration_lookahead.xml
@@ -1,6 +1,7 @@
 <h:html xmlns="http://www.w3.org/2002/xforms"
         xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa"
-        xmlns:orx="http://openrosa.org/jr/xforms" xmlns:vellum="http://commcarehq.org/xforms/vellum_markup"
+        xmlns:orx="http://openrosa.org/jr/xforms"
+        xmlns:vellum="http://commcarehq.org/xforms/vellum_markup"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <h:head>
         <h:title>Model Iteration</h:title>
@@ -8,7 +9,9 @@
             <instance>
                 <data name="Model Iteration"
                       uiVersion="1"
-                      version="279" xmlns="http://openrosa.org/formdesigner/21D20D14-BF66-497D-8258-8356080CDB3C" xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
+                      version="279"
+                      xmlns="http://openrosa.org/formdesigner/21D20D14-BF66-497D-8258-8356080CDB3C"
+                      xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
 
                     <!-- This is just here so the form works independently. This data connector might be case data or something instead. -->
                     <itemdata>
@@ -27,6 +30,7 @@
                             <value/>
                             <target/>
                             <target_value/>
+                            <relevancy_depending_on_future/>
                         </iterator>
                     </myiterator>
 
@@ -45,17 +49,24 @@
             <bind calculate="join(' ', /data/itemdata/item/@id)"
                   nodeset="/data/myiterator/elements"/>
 
-            <setvalue event="jr-insert" ref="/data/myiterator/iterator/@index"
+            <bind calculate="100"
+                  nodeset="/data/myiterator/iterator/relevancy_depending_on_future"
+                  relevant="/data/myiterator/iterator/target_value != ''"/>
+
+            <setvalue event="jr-insert"
+                      ref="/data/myiterator/iterator/@index"
                       value="int(/data/myiterator/cur_element)"/>
 
-            <bind calculate="count-selected(/data/myiterator/elements)" nodeset="/data/myiterator/num_elements"
+            <bind calculate="count-selected(/data/myiterator/elements)"
+                  nodeset="/data/myiterator/num_elements"
                   type="int"/>
             <bind calculate="count(/data/myiterator/iterator)"
                   nodeset="/data/myiterator/cur_element"/>
 
             <bind calculate="selected-at(/data/myiterator/elements,../@index)"
                   nodeset="/data/myiterator/iterator/@id"/>
-            <bind nodeset="/data/myiterator/iterator/question" relevant="false()"/>
+            <bind nodeset="/data/myiterator/iterator/question"
+                  relevant="false()"/>
 
             <itext>
                 <translation default="" lang="en">

--- a/core/src/test/resources/xform_tests/model_iteration_lookahead.xml
+++ b/core/src/test/resources/xform_tests/model_iteration_lookahead.xml
@@ -1,0 +1,91 @@
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa"
+        xmlns:orx="http://openrosa.org/jr/xforms" xmlns:vellum="http://commcarehq.org/xforms/vellum_markup"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Model Iteration</h:title>
+        <model>
+            <instance>
+                <data name="Model Iteration"
+                      uiVersion="1"
+                      version="279" xmlns="http://openrosa.org/formdesigner/21D20D14-BF66-497D-8258-8356080CDB3C" xmlns:jrm="http://dev.commcarehq.org/jr/xforms">
+
+                    <!-- This is just here so the form works independently. This data connector might be case data or something instead. -->
+                    <itemdata>
+                        <item id="a" target="b" value="10">Item A</item>
+                        <item id="b" target="" value="20">Item B</item>
+                    </itemdata>
+
+                    <itemsetanswer/>
+
+                    <myiterator>
+                        <elements/>
+                        <num_elements/>
+                        <cur_element/>
+                        <iterator id="" index="" jr:template="">
+                            <question/>
+                            <value/>
+                            <target/>
+                            <target_value/>
+                        </iterator>
+                    </myiterator>
+
+                </data>
+
+            </instance>
+
+
+            <bind calculate="/data/itemdata/item[@id=current()/../@id]/@value"
+                  nodeset="/data/myiterator/iterator/value"/>
+            <bind calculate="/data/itemdata/item[@id=current()/../@id]/@target"
+                  nodeset="/data/myiterator/iterator/target"/>
+            <bind calculate="/data/myiterator/iterator[@id = current()/../target]/value"
+                  nodeset="/data/myiterator/iterator/target_value"/>
+
+            <bind calculate="join(' ', /data/itemdata/item/@id)"
+                  nodeset="/data/myiterator/elements"/>
+
+            <setvalue event="jr-insert" ref="/data/myiterator/iterator/@index"
+                      value="int(/data/myiterator/cur_element)"/>
+
+            <bind calculate="count-selected(/data/myiterator/elements)" nodeset="/data/myiterator/num_elements"
+                  type="int"/>
+            <bind calculate="count(/data/myiterator/iterator)"
+                  nodeset="/data/myiterator/cur_element"/>
+
+            <bind calculate="selected-at(/data/myiterator/elements,../@index)"
+                  nodeset="/data/myiterator/iterator/@id"/>
+            <bind nodeset="/data/myiterator/iterator/question" relevant="false()"/>
+
+            <itext>
+                <translation default="" lang="en">
+                    <text id="itemsetanswer-label">
+                        <value>Choose which items to include in the iteration</value>
+                    </text>
+                    <text id="repeatable-label">
+                        <value>Label for the repeat</value>
+                    </text>
+                    <text id="myiterator-question-label">
+                        <!-- This question text relies on the pattern of selecting the ID'd node from the datasource. that should be something that vellum makes relatively easy (although updating them will be hard and can be ignored for now) -->
+                        <value>Model
+                            <output ref="/data/itemdata/item[@id=current()/../@id]"/>
+                            is associated with the value:
+                            <output ref="/data/itemdata/item[@id=current()/../@id]/@value"/>
+                        </value>
+                    </text>
+
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+
+        <group>
+            <repeat nodeset="/data/myiterator/iterator" jr:count="/data/myiterator/num_elements">
+                <trigger ref="question">
+                    <label ref="jr:itext('myiterator-question-label')"></label>
+                </trigger>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/core/src/test/resources/xform_tests/model_iteration_lookahead.xml
+++ b/core/src/test/resources/xform_tests/model_iteration_lookahead.xml
@@ -29,8 +29,10 @@
                             <question/>
                             <value/>
                             <target/>
-                            <target_value/>
-                            <relevancy_depending_on_future/>
+                            <target_value>
+                                <value/>
+                                <value_again/>
+                            </target_value>
                         </iterator>
                     </myiterator>
 
@@ -43,15 +45,28 @@
                   nodeset="/data/myiterator/iterator/value"/>
             <bind calculate="/data/itemdata/item[@id=current()/../@id]/@target"
                   nodeset="/data/myiterator/iterator/target"/>
-            <bind calculate="/data/myiterator/iterator[@id = current()/../target]/value"
-                  nodeset="/data/myiterator/iterator/target_value"/>
+            <bind calculate="/data/myiterator/iterator[@id = current()/../../target]/value"
+                  nodeset="/data/myiterator/iterator/target_value/value"/>
 
             <bind calculate="join(' ', /data/itemdata/item/@id)"
                   nodeset="/data/myiterator/elements"/>
 
-            <bind calculate="100"
-                  nodeset="/data/myiterator/iterator/relevancy_depending_on_future"
-                  relevant="/data/myiterator/iterator/target_value != ''"/>
+            <!--
+            Tests the propagation of trigger context widening:
+            since the nodeset and a subexpression in the calculate share a
+            prefix path and there are predicates in that path, when this
+            calculate is triggered it has to widden its context for all path
+            steps including and after the occurrence of that predicate. Tricky
+            part is if the triggering occurs due to an earlier, dominating
+            calculate being fired, which also has had widening applied to it,
+            we must take the minimum of the two.
+
+            If this didn't work correctly, you might expect the
+            /data/myiterator/iterator/target_value/value ref to not reflect the
+            most up-to-date value
+            -->
+            <bind calculate="/data/myiterator/iterator/target_value[true()]/value"
+                  nodeset="/data/myiterator/iterator/target_value/value_again" />
 
             <setvalue event="jr-insert"
                       ref="/data/myiterator/iterator/@index"


### PR DESCRIPTION
Android-level 'form save on complete' re-fires all triggerables.  Disabling this, for performance reasons, exposes a bug were triggerables that fire on repeat inserts and have expressions that reference future (to be inserted) repeat entries never get re-fired due to over contextualization. This has been fixed by generalizing the triggerable context where path predicates are present for intersecting references in the triggerable expression.

For instance:
```
<bind 
    calculate="/data/myiterator/iterator[@id = current()/../target]/value" 
    nodeset="/data/myiterator/iterator/target_value"/>
```
This calculation triggerable should fire for all entries in `/data/myiterator/iterator` because `/data/myiterator/iterator[@id = current()/../target]/value` might reference an entry of `/data/myiterator/iterator` that doesn't yet exist. Making it fire for all entries means that when that entry exists (is created), the value will correctly get set.