### PR TITLE
Minor optimizations/refactors with case loading

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
+++ b/core/src/main/java/org/javarosa/core/model/condition/EvaluationContext.java
@@ -47,8 +47,8 @@ public class EvaluationContext {
     // Unambiguous anchor reference for relative paths
     private TreeReference contextNode;
 
-    private Hashtable functionHandlers;
-    private Hashtable variables;
+    private Hashtable<String, IFunctionHandler> functionHandlers;
+    private Hashtable<String, Object> variables;
 
     // Do we want to evaluate constraints?
     public boolean isConstraint;
@@ -89,12 +89,12 @@ public class EvaluationContext {
         //TODO: These should be deep, not shallow
         this.functionHandlers = base.functionHandlers;
         this.formInstances = base.formInstances;
-        this.variables = new Hashtable();
+        this.variables = new Hashtable<String, Object>();
 
         //TODO: this is actually potentially much slower than
         //our old strategy (but is needed for this object to
         //be threadsafe). We should evaluate the potential impact.
-        this.setVariables(base.variables);
+        this.shallowVariablesCopy(base.variables);
 
         this.contextNode = base.contextNode;
         this.instance = base.instance;
@@ -140,8 +140,8 @@ public class EvaluationContext {
         this.formInstances = formInstances;
         this.instance = instance;
         this.contextNode = TreeReference.rootRef();
-        functionHandlers = new Hashtable();
-        variables = new Hashtable();
+        functionHandlers = new Hashtable<String, IFunctionHandler>();
+        variables = new Hashtable<String, Object>();
     }
 
     public DataInstance getInstance(String id) {
@@ -180,10 +180,17 @@ public class EvaluationContext {
         return outputTextForm;
     }
 
+    private void shallowVariablesCopy(Hashtable<String, Object> variablesToCopy) {
+        for (Enumeration e = variablesToCopy.keys(); e.hasMoreElements(); ) {
+            String key = (String)e.nextElement();
+            variables.put(key, variablesToCopy.get(key));
+        }
+    }
+
     public void setVariables(Hashtable<String, ?> variables) {
         for (Enumeration e = variables.keys(); e.hasMoreElements(); ) {
-            String var = (String)e.nextElement();
-            setVariable(var, variables.get(var));
+            String key = (String)e.nextElement();
+            setVariable(key, variables.get(key));
         }
     }
 

--- a/core/src/main/java/org/javarosa/core/model/utils/CacheHost.java
+++ b/core/src/main/java/org/javarosa/core/model/utils/CacheHost.java
@@ -19,8 +19,7 @@ public interface CacheHost {
      * are constant time entities that require no side computation, and is unlikely
      * that optimizations will work if they are not.
      */
-    public String getCacheIndex(TreeReference ref);
-
+    String getCacheIndex(TreeReference ref);
 
     /**
      * Evaluates whether the provided tree reference pattern can
@@ -34,7 +33,7 @@ public interface CacheHost {
      * cache index, but merely that if one is returned that it will
      * be meaningful
      */
-    public boolean isReferencePatternCachable(TreeReference ref);
+    boolean isReferencePatternCachable(TreeReference ref);
 
     /**
      * Get the set of parameters expected to yield the best results for
@@ -49,5 +48,5 @@ public interface CacheHost {
      * String[] keys = returvalue[0];
      * String[] values = returnvalue[1];
      */
-    public String[][] getCachePrimeGuess();
+    String[][] getCachePrimeGuess();
 }

--- a/core/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/core/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -28,7 +28,9 @@ public class DateUtils {
      */
     public static final int FORMAT_TIMESTAMP_HTTP = 9;
 
-    public static final long DAY_IN_MS = 86400000l;
+    public static final long DAY_IN_MS = 86400000L;
+    private static final Date EPOCH_DATE = getDate(1970, 1, 1);
+    private final static long EPOCH_TIME = roundDate(EPOCH_DATE).getTime();
 
     public DateUtils() {
         super();
@@ -459,7 +461,6 @@ public class DateUtils {
         // it in the local timezone.
 
         c.setTimeZone(TimeZone.getDefault());
-        long four = c.get(Calendar.HOUR);
 
         DateFields adjusted = getFields(c.getTime());
 
@@ -575,7 +576,6 @@ public class DateUtils {
      * the provided date and the current date.
      */
     private static String formatDaysFromToday(DateFields f) {
-        String daysAgoStr = "";
         Date d = DateUtils.getDate(f);
         int daysAgo = DateUtils.daysSinceEpoch(new Date()) - DateUtils.daysSinceEpoch(d);
 
@@ -711,12 +711,12 @@ public class DateUtils {
      * @return The number of days (as a double precision floating point) since the Epoch
      */
     public static int daysSinceEpoch(Date date) {
-        return dateDiff(getDate(1970, 1, 1), date);
+        return (int)MathUtils.divLongNotSuck(roundDate(date).getTime() - EPOCH_TIME + DAY_IN_MS / 2, DAY_IN_MS);
     }
 
 
     public static Double fractionalDaysSinceEpoch(Date a) {
-        return new Double((a.getTime() - getDate(1970, 1, 1).getTime()) / (double)DAY_IN_MS);
+        return new Double((a.getTime() - EPOCH_DATE.getTime()) / (double)DAY_IN_MS);
     }
 
     /**


### PR DESCRIPTION
Cache intermediate date variable to avoid recomputing it. Saves a hundred or two milliseconds on case loading :turtle: :turtle: :turtle: 