### PR TITLE
Prevent NPE on when setting TreeElement root to empty ref

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -88,7 +88,7 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
             root.setInstanceName(this.getInstanceId());
         }
         if (topLevel != null) {
-            root.addChild(topLevel);
+           root.addChild(topLevel);
         }
     }
 


### PR DESCRIPTION
Some refactors and a switch of order of ops to avoid an NPE