### PR TITLE
Add back in meta data function used by TF

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -270,6 +270,14 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         return new String[]{META_XMLNS, META_ID};
     }
 
+    public Hashtable getMetaData() {
+        Hashtable data = new Hashtable();
+        for (String key : getMetaDataFields()) {
+            data.put(key, getMetaData(key));
+        }
+        return data;
+    }
+
     @Override
     public Object getMetaData(String fieldName) {
         if (META_XMLNS.equals(fieldName)) {

--- a/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/FormInstance.java
@@ -270,6 +270,8 @@ public class FormInstance extends DataInstance<TreeElement> implements Persistab
         return new String[]{META_XMLNS, META_ID};
     }
 
+    // used by TouchForms
+    @SuppressWarnings("unused")
     public Hashtable getMetaData() {
         Hashtable data = new Hashtable();
         for (String key : getMetaDataFields()) {


### PR DESCRIPTION
Add back in function used by Touchforms removed in https://github.com/dimagi/javarosa/commit/cbea2ba72473c844b3bf08f59f32d760e91fa620

@phillipm I know Jython causes an annoying state where its very unclear what functions are being used, but can you refrain from removing more functions from javarosa/core and commcare/[backend, cases] for the time being? Hopefully in the near future (2-3 months) we'll be off Jython and the spring repository will make clear what functions are being used