### PR TITLE
Don't allow ActionController to deserialize to null; prevents NPE crash

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1492,7 +1492,7 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
         extensions = (Vector)ExtUtil.read(dis, new ExtWrapListPoly(), pf);
 
         setEvaluationContext(new EvaluationContext(null));
-        actionController = (ActionController)ExtUtil.read(dis, new ExtWrapTagged(), pf);
+        actionController = (ActionController)ExtUtil.read(dis, ActionController.class, pf);
     }
 
     /**
@@ -1558,7 +1558,7 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
 
         ExtUtil.write(dos, new ExtWrapMap(formInstances, new ExtWrapTagged()));
         ExtUtil.write(dos, new ExtWrapListPoly(extensions));
-        ExtUtil.write(dos, new ExtWrapTagged(actionController));
+        ExtUtil.write(dos, actionController);
     }
 
     public void collapseIndex(FormIndex index,

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1492,7 +1492,7 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
         extensions = (Vector)ExtUtil.read(dis, new ExtWrapListPoly(), pf);
 
         setEvaluationContext(new EvaluationContext(null));
-        actionController = (ActionController)ExtUtil.read(dis, new ExtWrapNullable(ActionController.class), pf);
+        actionController = (ActionController)ExtUtil.read(dis, new ExtWrapTagged(), pf);
     }
 
     /**
@@ -1558,7 +1558,7 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
 
         ExtUtil.write(dos, new ExtWrapMap(formInstances, new ExtWrapTagged()));
         ExtUtil.write(dos, new ExtWrapListPoly(extensions));
-        ExtUtil.write(dos, new ExtWrapNullable(actionController));
+        ExtUtil.write(dos, new ExtWrapTagged(actionController));
     }
 
     public void collapseIndex(FormIndex index,


### PR DESCRIPTION
I've been coming against residual NPE crashes where form loading fails because the `FormDef`'s `ActionController` doesn't fail hard when deserialization fails, but rather to deserializes to `null`.

This PR makes form deserialization fail when the `ActionController` can't be deserialized. This forces the form to be re-read from xml and re-serialized.

To reproduce, load a form using an intent on master, then build https://github.com/dimagi/commcare-odk/pull/1128 and load the same form. The change in how `IntentCallout` is serialized somehow causes the `FormDef` deserialization to not load the `ActionController` correctly.

This change makes it so that if we change the serialization scheme of `ActionController`, or I guess other things as seen in the reproduction steps above, then we won't cause user level crashes when CommCare is updated on their devices and the load a form that had previously been loaded on older version of CommCare.