### PR TITLE
Optimize case list loading

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -230,7 +230,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         addChild(child, false);
     }
 
-    private void addChild(TreeElement child, boolean checkDuplicate) {
+    public void addChild(TreeElement child, boolean assumeUniqueChildNames) {
         if (!isChildable()) {
             throw new RuntimeException("Can't add children to node that has data value!");
         }
@@ -239,12 +239,6 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
             throw new RuntimeException("Cannot add child with an unbound index!");
         }
 
-        if (checkDuplicate) {
-            TreeElement existingChild = getChild(child.name, child.multiplicity);
-            if (existingChild != null) {
-                throw new RuntimeException("Attempted to add duplicate child!");
-            }
-        }
         if (children == null) {
             children = new Vector<TreeElement>();
         }
@@ -256,7 +250,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
             if (anchor != null) {
                 i = referenceIndexOf(children, anchor);
             }
-        } else {
+        } else if (!assumeUniqueChildNames) {
             TreeElement anchor = getChild(child.getName(),
                     (child.getMult() == 0 ? TreeReference.INDEX_TEMPLATE : child.getMult() - 1));
             if (anchor != null) {


### PR DESCRIPTION
Adding an optional flag for assuming unique child names in `addChild()`, which enables us to skip the very inefficient step of checking what the multiplicity should be.

Also removing an unused flag from the same method.

cross-request: https://github.com/dimagi/commcare/pull/274