### PR TITLE
XPath related refactors and XPathPathExpr.getReference() caching

### DIFF
--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFilterExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFilterExpr.java
@@ -85,9 +85,9 @@ public class XPathFilterExpr extends XPathExpression {
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
-        Vector v = new Vector();
-        for (int i = 0; i < predicates.length; i++) {
-            v.addElement(predicates[i]);
+        Vector<XPathExpression> v = new Vector<XPathExpression>();
+        for (XPathExpression predicate : predicates) {
+            v.addElement(predicate);
         }
 
         ExtUtil.write(out, new ExtWrapTagged(x));

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -347,13 +347,9 @@ public class XPathPathExpr extends XPathExpression {
                 return false;
             }
 
-            if (steps.length != x.steps.length) {
-                return false;
-            } else {
-                for (int i = 0; i < steps.length; i++) {
-                    if (!steps[i].matches(x.steps[i])) {
-                        return false;
-                    }
+            for (int i = 0; i < steps.length; i++) {
+                if (!steps[i].matches(x.steps[i])) {
+                    return false;
                 }
             }
 

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -43,6 +43,7 @@ public class XPathPathExpr extends XPathExpression {
 
     public int init_context;
     public XPathStep[] steps;
+    private TreeReference cachedReference;
 
     //for INIT_CONTEXT_EXPR only
     public XPathFilterExpr filtExpr;
@@ -69,6 +70,9 @@ public class XPathPathExpr extends XPathExpression {
      * @return a reference built from this path expression
      */
     public TreeReference getReference() throws XPathUnsupportedException {
+        if (cachedReference != null) {
+            return cachedReference;
+        }
         TreeReference ref = new TreeReference();
         boolean parentsAllowed;
         // process the beginning of the reference
@@ -160,6 +164,7 @@ public class XPathPathExpr extends XPathExpression {
                 ref.addPredicate(ref.size() - 1, v);
             }
         }
+        cachedReference = ref;
         return ref;
     }
 

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathPathExpr.java
@@ -155,10 +155,9 @@ public class XPathPathExpr extends XPathExpression {
             }
 
             if (step.predicates.length > 0) {
-                int refLevel = ref.getRefLevel();
                 Vector<XPathExpression> v = new Vector<XPathExpression>();
-                for (int j = 0; j < step.predicates.length; j++) {
-                    v.addElement(step.predicates[j]);
+                for (XPathExpression predicate : step.predicates) {
+                    v.addElement(predicate);
                 }
                 // add the predicate vector to the last step in the ref
                 ref.addPredicate(ref.size() - 1, v);
@@ -171,7 +170,6 @@ public class XPathPathExpr extends XPathExpression {
     @Override
     public XPathNodeset evalRaw(DataInstance m, EvaluationContext ec) {
         TreeReference genericRef = getReference();
-
         TreeReference ref;
 
         if (genericRef.getContext() == TreeReference.CONTEXT_ORIGINAL) {
@@ -202,7 +200,7 @@ public class XPathPathExpr extends XPathExpression {
             m = ec.getMainInstance();
 
             if (m == null) {
-                String refStr = ref == null ? "" : ref.toString(true);
+                String refStr = ref.toString(true);
                 throw new XPathException("Cannot evaluate the reference [" + refStr + "] in the current evaluation context. No default instance has been declared!");
             }
         }
@@ -386,9 +384,9 @@ public class XPathPathExpr extends XPathExpression {
             ExtUtil.write(out, filtExpr);
         }
 
-        Vector v = new Vector();
-        for (int i = 0; i < steps.length; i++) {
-            v.addElement(steps[i]);
+        Vector<XPathStep> v = new Vector<XPathStep>();
+        for (XPathStep step : steps) {
+            v.addElement(step);
         }
         ExtUtil.write(out, new ExtWrapList(v));
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathStep.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathStep.java
@@ -37,6 +37,7 @@ public class XPathStep implements Externalizable {
     public static final int TEST_TYPE_PROCESSING_INSTRUCTION = 6;
 
     private static Interner<XPathStep> refs;
+    public static boolean XPathStepInterningEnabled = true;
 
     public int axis;
     public int test;
@@ -216,7 +217,10 @@ public class XPathStep implements Externalizable {
     protected boolean matches(XPathStep o) {
         if (o != null) {
             //shortcuts for faster evaluation
-            if (axis != o.axis || (test != o.test && !((o.test == TEST_NAME && this.test == TEST_NAME_WILDCARD) || (this.test == TEST_NAME && o.test == TEST_NAME_WILDCARD))) || predicates.length != o.predicates.length) {
+            if (axis != o.axis
+                    || (test != o.test && !((o.test == TEST_NAME && this.test == TEST_NAME_WILDCARD)
+                    || (this.test == TEST_NAME && o.test == TEST_NAME_WILDCARD)))
+                    || predicates.length != o.predicates.length) {
                 return false;
             }
 
@@ -248,7 +252,11 @@ public class XPathStep implements Externalizable {
 
     @Override
     public int hashCode() {
-        int code = this.axis ^ this.test ^ (this.name == null ? 0 : this.name.hashCode()) ^ (this.literal == null ? 0 : this.literal.hashCode()) ^ (this.namespace == null ? 0 : this.namespace.hashCode());
+        int code = this.axis
+                ^ this.test
+                ^ (this.name == null ? 0 : this.name.hashCode())
+                ^ (this.literal == null ? 0 : this.literal.hashCode())
+                ^ (this.namespace == null ? 0 : this.namespace.hashCode());
         for (XPathExpression xpe : predicates) {
             code ^= xpe.hashCode();
         }
@@ -274,8 +282,9 @@ public class XPathStep implements Externalizable {
 
         Vector v = (Vector)ExtUtil.read(in, new ExtWrapListPoly(), pf);
         predicates = new XPathExpression[v.size()];
-        for (int i = 0; i < predicates.length; i++)
+        for (int i = 0; i < predicates.length; i++) {
             predicates[i] = (XPathExpression)v.elementAt(i);
+        }
     }
 
     @Override
@@ -295,13 +304,12 @@ public class XPathStep implements Externalizable {
                 break;
         }
 
-        Vector v = new Vector();
-        for (int i = 0; i < predicates.length; i++)
-            v.addElement(predicates[i]);
+        Vector<XPathExpression> v = new Vector<XPathExpression>();
+        for (XPathExpression predicate : predicates) {
+            v.addElement(predicate);
+        }
         ExtUtil.write(out, new ExtWrapListPoly(v));
     }
-
-    public static boolean XPathStepInterningEnabled = true;
 
     public XPathStep intern() {
         if (!XPathStepInterningEnabled || refs == null) {

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathStep.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathStep.java
@@ -38,25 +38,6 @@ public class XPathStep implements Externalizable {
 
     private static Interner<XPathStep> refs;
 
-    /**
-     * Used by J2ME
-     */
-    public static void attachInterner(Interner<XPathStep> refs) {
-        XPathStep.refs = refs;
-    }
-
-    public static XPathStep ABBR_SELF() {
-        return new XPathStep(AXIS_SELF, TEST_TYPE_NODE);
-    }
-
-    public static XPathStep ABBR_PARENT() {
-        return new XPathStep(AXIS_PARENT, TEST_TYPE_NODE);
-    }
-
-    public static XPathStep ABBR_DESCENDANTS() {
-        return new XPathStep(AXIS_DESCENDANT_OR_SELF, TEST_TYPE_NODE);
-    }
-
     public int axis;
     public int test;
     public XPathExpression[] predicates;
@@ -83,6 +64,25 @@ public class XPathStep implements Externalizable {
     public XPathStep(int axis, String namespace) {
         this(axis, TEST_NAMESPACE_WILDCARD);
         this.namespace = namespace;
+    }
+
+    public static XPathStep ABBR_SELF() {
+        return new XPathStep(AXIS_SELF, TEST_TYPE_NODE);
+    }
+
+    public static XPathStep ABBR_PARENT() {
+        return new XPathStep(AXIS_PARENT, TEST_TYPE_NODE);
+    }
+
+    public static XPathStep ABBR_DESCENDANTS() {
+        return new XPathStep(AXIS_DESCENDANT_OR_SELF, TEST_TYPE_NODE);
+    }
+
+    /**
+     * Used by J2ME
+     */
+    public static void attachInterner(Interner<XPathStep> refs) {
+        XPathStep.refs = refs;
     }
 
     @Override

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathStep.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathStep.java
@@ -214,27 +214,25 @@ public class XPathStep implements Externalizable {
      * Matching is reflexive, consistent, and symmetric, but _not_ transitive.
      */
     protected boolean matches(XPathStep o) {
-        if (o instanceof XPathStep) {
-            XPathStep x = o;
-
+        if (o != null) {
             //shortcuts for faster evaluation
-            if (axis != x.axis || (test != x.test && !((x.test == TEST_NAME && this.test == TEST_NAME_WILDCARD) || (this.test == TEST_NAME && x.test == TEST_NAME_WILDCARD))) || predicates.length != x.predicates.length) {
+            if (axis != o.axis || (test != o.test && !((o.test == TEST_NAME && this.test == TEST_NAME_WILDCARD) || (this.test == TEST_NAME && o.test == TEST_NAME_WILDCARD))) || predicates.length != o.predicates.length) {
                 return false;
             }
 
             switch (test) {
                 case TEST_NAME:
-                    if (x.test != TEST_NAME_WILDCARD && !name.equals(x.name)) {
+                    if (o.test != TEST_NAME_WILDCARD && !name.equals(o.name)) {
                         return false;
                     }
                     break;
                 case TEST_NAMESPACE_WILDCARD:
-                    if (!namespace.equals(x.namespace)) {
+                    if (!namespace.equals(o.namespace)) {
                         return false;
                     }
                     break;
                 case TEST_TYPE_PROCESSING_INSTRUCTION:
-                    if (!ExtUtil.equals(literal, x.literal, false)) {
+                    if (!ExtUtil.equals(literal, o.literal, false)) {
                         return false;
                     }
                     break;
@@ -242,7 +240,7 @@ public class XPathStep implements Externalizable {
                     break;
             }
 
-            return ExtUtil.arrayEquals(predicates, x.predicates, false);
+            return ExtUtil.arrayEquals(predicates, o.predicates, false);
         } else {
             return false;
         }


### PR DESCRIPTION
Refactors and very simple caching of `XPathPathExpr.getReferenec()` which, as far as I've tested, has very small performance gains, but is worth doing based on its simplicity.

Review commit-by-commit