### PR TITLE
Fix binary op expression equality logic

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -750,7 +750,7 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
                 // when we grabbed all triggerables that target children of the
                 // repeat entry (via initTriggerablesRootedBy). Hence skip them
                 if (!isRepeatEntryInit && t.isCascadingToChildren()) {
-                    //updatedNodes = findCascadeReferences(target, updatedNodes);
+                    updatedNodes = findCascadeReferences(target, updatedNodes);
                 }
 
                 addTriggerablesTargetingNodes(updatedNodes, destination);
@@ -779,14 +779,14 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
             if (target.getMultLast() == TreeReference.INDEX_ATTRIBUTE) {
                 // attributes don't have children that might change under
                 // contextualization
-                //cachedCascadingChildren.register(target, updatedNodes);
+                cachedCascadingChildren.register(target, updatedNodes);
             } else {
                 Vector<TreeReference> expandedRefs = exprEvalContext.expandReference(target);
                 if (expandedRefs.size() > 0) {
                     AbstractTreeElement template = mainInstance.getTemplatePath(target);
                     if (template != null) {
                         addChildrenOfElement(template, updatedNodes);
-                        //cachedCascadingChildren.register(target, updatedNodes);
+                        cachedCascadingChildren.register(target, updatedNodes);
                     } else {
                         // NOTE PLM: entirely possible this can be removed if
                         // the getTemplatePath code is updated to handle

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -750,7 +750,7 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
                 // when we grabbed all triggerables that target children of the
                 // repeat entry (via initTriggerablesRootedBy). Hence skip them
                 if (!isRepeatEntryInit && t.isCascadingToChildren()) {
-                    updatedNodes = findCascadeReferences(target, updatedNodes);
+                    //updatedNodes = findCascadeReferences(target, updatedNodes);
                 }
 
                 addTriggerablesTargetingNodes(updatedNodes, destination);
@@ -779,14 +779,14 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
             if (target.getMultLast() == TreeReference.INDEX_ATTRIBUTE) {
                 // attributes don't have children that might change under
                 // contextualization
-                cachedCascadingChildren.register(target, updatedNodes);
+                //cachedCascadingChildren.register(target, updatedNodes);
             } else {
                 Vector<TreeReference> expandedRefs = exprEvalContext.expandReference(target);
                 if (expandedRefs.size() > 0) {
                     AbstractTreeElement template = mainInstance.getTemplatePath(target);
                     if (template != null) {
                         addChildrenOfElement(template, updatedNodes);
-                        cachedCascadingChildren.register(target, updatedNodes);
+                        //cachedCascadingChildren.register(target, updatedNodes);
                     } else {
                         // NOTE PLM: entirely possible this can be removed if
                         // the getTemplatePath code is updated to handle

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathArithExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathArithExpr.java
@@ -98,6 +98,7 @@ public class XPathArithExpr extends XPathBinaryOpExpr {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof XPathArithExpr) && binOpEquals((XPathBinaryOpExpr)o);
+        return (this == o) ||
+                ((o instanceof XPathArithExpr) && binOpEquals((XPathBinaryOpExpr)o));
     }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathArithExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathArithExpr.java
@@ -95,4 +95,9 @@ public class XPathArithExpr extends XPathBinaryOpExpr {
 
         return prettyA + opString + prettyB;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof XPathArithExpr) && binOpEquals((XPathBinaryOpExpr)o);
+    }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathBinaryOpExpr.java
@@ -31,13 +31,10 @@ public abstract class XPathBinaryOpExpr extends XPathOpExpr {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (o instanceof XPathBinaryOpExpr) {
-            XPathBinaryOpExpr x = (XPathBinaryOpExpr)o;
-            return op == x.op && a.equals(x.a) && b.equals(x.b);
-        } else {
-            return false;
-        }
+    public abstract boolean equals(Object o);
+
+    protected boolean binOpEquals(XPathBinaryOpExpr binaryOpExpr) {
+        return op == binaryOpExpr.op && a.equals(binaryOpExpr.a) && b.equals(binaryOpExpr.b);
     }
 
     @Override

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathBoolExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathBoolExpr.java
@@ -72,4 +72,8 @@ public class XPathBoolExpr extends XPathBinaryOpExpr {
         return prettyA + opString + prettyB;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof XPathBoolExpr) && binOpEquals((XPathBinaryOpExpr)o);
+    }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathBoolExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathBoolExpr.java
@@ -74,6 +74,7 @@ public class XPathBoolExpr extends XPathBinaryOpExpr {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof XPathBoolExpr) && binOpEquals((XPathBinaryOpExpr)o);
+        return (this == o) ||
+                ((o instanceof XPathBoolExpr) && binOpEquals((XPathBinaryOpExpr)o));
     }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathCmpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathCmpExpr.java
@@ -165,6 +165,7 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof XPathCmpExpr) && binOpEquals((XPathBinaryOpExpr)o);
+        return (this == o) ||
+                ((o instanceof XPathCmpExpr) && binOpEquals((XPathBinaryOpExpr)o));
     }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathCmpExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathCmpExpr.java
@@ -162,4 +162,9 @@ public class XPathCmpExpr extends XPathBinaryOpExpr {
 
         return prettyA + opString + prettyB;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof XPathCmpExpr) && binOpEquals((XPathBinaryOpExpr)o);
+    }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathEqExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathEqExpr.java
@@ -106,4 +106,9 @@ public class XPathEqExpr extends XPathBinaryOpExpr {
             return prettyA + " != " + prettyB;
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof XPathEqExpr) && binOpEquals((XPathBinaryOpExpr)o);
+    }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathEqExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathEqExpr.java
@@ -109,6 +109,7 @@ public class XPathEqExpr extends XPathBinaryOpExpr {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof XPathEqExpr) && binOpEquals((XPathBinaryOpExpr)o);
+        return (this == o) ||
+                ((o instanceof XPathEqExpr) && binOpEquals((XPathBinaryOpExpr)o));
     }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
@@ -43,4 +43,9 @@ public class XPathUnionExpr extends XPathBinaryOpExpr {
     public String toPrettyString() {
         return "unsupported union operation";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o instanceof XPathUnionExpr) && binOpEquals((XPathBinaryOpExpr)o);
+    }
 }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathUnionExpr.java
@@ -46,6 +46,7 @@ public class XPathUnionExpr extends XPathBinaryOpExpr {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof XPathUnionExpr) && binOpEquals((XPathBinaryOpExpr)o);
+        return (this == o) ||
+                ((o instanceof XPathUnionExpr) && binOpEquals((XPathBinaryOpExpr)o));
     }
 }

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -315,7 +315,7 @@ public class FormDefTest {
         double expectedAge = (double) (diff / MILLISECONDS_IN_A_YEAR);
 
         ExprEvalUtils.assertEqualsXpathEval("Check that a default value for the age question was " +
-                "set correctly based upon provided answer to birthday question",
+                        "set correctly based upon provided answer to birthday question",
                 expectedAge, "/data/age", evalCtx);
     }
 
@@ -398,6 +398,31 @@ public class FormDefTest {
                 "20", "/data/myiterator/iterator[1]/target_value", evalCtx);
         ExprEvalUtils.assertEqualsXpathEval("",
                 100.0, "/data/myiterator/iterator[1]/relevancy_depending_on_future", evalCtx);
+    }
+
+    @Test
+    public void testDisplayConditionsRegression() throws Exception {
+        FormParseInit fpi =
+                new FormParseInit("/xform_tests/test_display_conditions_regression.xml");
+        FormEntryController fec =  initFormEntry(fpi);
+
+        boolean visibleLabelWasPresent = false;
+        do {
+            QuestionDef q = fpi.getCurrentQuestion();
+            if (q == null || q.getTextID() == null || "".equals(q.getTextID())) {
+                continue;
+            }
+            if (q.getTextID().equals("visible-label")) {
+                visibleLabelWasPresent = true;
+            }
+            if (q.getTextID().equals("invisible-label")) {
+                //fail("Label whose display condition should be false was showing");
+            }
+        } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
+
+        if (!visibleLabelWasPresent) {
+            fail("Label whose display condition should be true was not showing");
+        }
     }
 
     private static void stepThroughEntireForm(FormEntryController fec) {

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -416,7 +416,7 @@ public class FormDefTest {
                 visibleLabelWasPresent = true;
             }
             if (q.getTextID().equals("invisible-label")) {
-                //fail("Label whose display condition should be false was showing");
+                fail("Label whose display condition should be false was showing");
             }
         } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
 

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -400,8 +400,14 @@ public class FormDefTest {
                 100.0, "/data/myiterator/iterator[1]/relevancy_depending_on_future", evalCtx);
     }
 
+    /**
+     * Testing that two identical bind conditions, modulo the operator (=, <),
+     * are treated as distict entities.  Regression test for an issue where
+     * `equals` method for binary conditions wasn't taking condition type
+     * (arith, bool, equality) into account.
+     */
     @Test
-    public void testDisplayConditionsRegression() throws Exception {
+    public void testSimilarBindConditionsAreDistinguished() throws Exception {
         FormParseInit fpi =
                 new FormParseInit("/xform_tests/test_display_conditions_regression.xml");
         FormEntryController fec =  initFormEntry(fpi);

--- a/core/src/test/java/org/javarosa/xpath/expr/test/XPathBinaryOpExprTest.java
+++ b/core/src/test/java/org/javarosa/xpath/expr/test/XPathBinaryOpExprTest.java
@@ -1,0 +1,67 @@
+package org.javarosa.xpath.expr.test;
+
+import org.javarosa.xpath.expr.XPathArithExpr;
+import org.javarosa.xpath.expr.XPathBoolExpr;
+import org.javarosa.xpath.expr.XPathCmpExpr;
+import org.javarosa.xpath.expr.XPathEqExpr;
+import org.javarosa.xpath.expr.XPathNumericLiteral;
+import org.javarosa.xpath.expr.XPathStringLiteral;
+import org.javarosa.xpath.expr.XPathUnionExpr;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Phillip Mates (pmates@dimagi.com)
+ */
+public class XPathBinaryOpExprTest {
+    /**
+     * Extensive checks of binary op expression equality logic, because we all
+     * know 'a > b' isn't the same as 'a = b', but we don't always write code
+     * that knows that...
+     */
+    @Test
+    public void equalityForDifferentBinaryOps() {
+        XPathStringLiteral leftStringExpr = new XPathStringLiteral("left side");
+        XPathNumericLiteral zero = new XPathNumericLiteral(0d);
+
+        // Setup expressions to test equality over.
+        // Note: these binary expressions make semantic sense
+        XPathArithExpr additionExpr = new XPathArithExpr(XPathArithExpr.ADD, leftStringExpr, zero);
+        XPathArithExpr subtractExpr = new XPathArithExpr(XPathArithExpr.SUBTRACT, leftStringExpr, zero);
+
+        XPathBoolExpr andExpr = new XPathBoolExpr(XPathBoolExpr.AND, leftStringExpr, zero);
+        XPathBoolExpr orExpr = new XPathBoolExpr(XPathBoolExpr.OR, leftStringExpr, zero);
+
+        XPathCmpExpr lessThanExpr = new XPathCmpExpr(XPathCmpExpr.LT, leftStringExpr, zero);
+        XPathCmpExpr greaterThanExpr = new XPathCmpExpr(XPathCmpExpr.GT, leftStringExpr, zero);
+
+        XPathEqExpr eqExpr = new XPathEqExpr(XPathEqExpr.EQ, leftStringExpr, zero);
+        XPathEqExpr neqExpr = new XPathEqExpr(XPathEqExpr.NEQ, leftStringExpr, zero);
+
+        XPathUnionExpr union = new XPathUnionExpr(leftStringExpr, zero);
+        XPathUnionExpr differentUnion = new XPathUnionExpr(zero, zero);
+
+        // basic equality tests over same subclass
+        Assert.assertEquals("Same + expression is equal", additionExpr, additionExpr);
+        Assert.assertNotEquals("+ not equal to  -", additionExpr, subtractExpr);
+        Assert.assertEquals("Same && expression is equal", andExpr, andExpr);
+        Assert.assertNotEquals("&& not equal to ||", andExpr, orExpr);
+        Assert.assertEquals("Same < expression is equal", lessThanExpr, lessThanExpr);
+        Assert.assertNotEquals("< not equal to  >", lessThanExpr, greaterThanExpr);
+        Assert.assertEquals("Same == expression is equal", eqExpr, eqExpr);
+        Assert.assertNotEquals("== not equal to !=", eqExpr, neqExpr);
+
+        // make sure different binary expressions with same op code aren't equal
+        Assert.assertNotEquals("+ not equal to &&", additionExpr, andExpr);
+        Assert.assertNotEquals("+ not equal to <", additionExpr, lessThanExpr);
+        Assert.assertNotEquals("+ not equal to ==", additionExpr, eqExpr);
+        Assert.assertNotEquals("- not equal to ||", subtractExpr, orExpr);
+        Assert.assertNotEquals("- not equal to >", subtractExpr, greaterThanExpr);
+        Assert.assertNotEquals("- not equal to !=", subtractExpr, neqExpr);
+
+        // make sure union equality, which doesn't have an op code, works
+        Assert.assertEquals("same union instance is equal to itself", union, union);
+        Assert.assertNotEquals(union, differentUnion);
+        Assert.assertNotEquals("+ not equal to union", additionExpr, union);
+    }
+}

--- a/core/src/test/java/org/javarosa/xpath/expr/test/XPathBinaryOpExprTest.java
+++ b/core/src/test/java/org/javarosa/xpath/expr/test/XPathBinaryOpExprTest.java
@@ -27,9 +27,11 @@ public class XPathBinaryOpExprTest {
         // Setup expressions to test equality over.
         // Note: these binary expressions make semantic sense
         XPathArithExpr additionExpr = new XPathArithExpr(XPathArithExpr.ADD, leftStringExpr, zero);
+        XPathArithExpr additionExprClone = new XPathArithExpr(XPathArithExpr.ADD, leftStringExpr, zero);
         XPathArithExpr subtractExpr = new XPathArithExpr(XPathArithExpr.SUBTRACT, leftStringExpr, zero);
 
         XPathBoolExpr andExpr = new XPathBoolExpr(XPathBoolExpr.AND, leftStringExpr, zero);
+        XPathBoolExpr andExprClone = new XPathBoolExpr(XPathBoolExpr.AND, leftStringExpr, zero);
         XPathBoolExpr orExpr = new XPathBoolExpr(XPathBoolExpr.OR, leftStringExpr, zero);
 
         XPathCmpExpr lessThanExpr = new XPathCmpExpr(XPathCmpExpr.LT, leftStringExpr, zero);
@@ -42,9 +44,11 @@ public class XPathBinaryOpExprTest {
         XPathUnionExpr differentUnion = new XPathUnionExpr(zero, zero);
 
         // basic equality tests over same subclass
-        Assert.assertEquals("Same + expression is equal", additionExpr, additionExpr);
+        Assert.assertEquals("Same + expression reference is equal", additionExpr, additionExpr);
+        Assert.assertEquals("Same + expression is equal", additionExpr, additionExprClone);
         Assert.assertNotEquals("+ not equal to  -", additionExpr, subtractExpr);
-        Assert.assertEquals("Same && expression is equal", andExpr, andExpr);
+        Assert.assertEquals("Same && expression reference is equal", andExpr, andExpr);
+        Assert.assertEquals("Same && expression is equal", andExpr, andExprClone);
         Assert.assertNotEquals("&& not equal to ||", andExpr, orExpr);
         Assert.assertEquals("Same < expression is equal", lessThanExpr, lessThanExpr);
         Assert.assertNotEquals("< not equal to  >", lessThanExpr, greaterThanExpr);

--- a/core/src/test/resources/xform_tests/test_display_conditions_regression.xml
+++ b/core/src/test/resources/xform_tests/test_display_conditions_regression.xml
@@ -1,0 +1,46 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Label Display Conditions Test</h:title>
+        <model>
+            <instance>
+                <data
+                    name="display conditions"
+                    xmlns="http://openrosa.org/test/actions"
+                    uiVersion="1"
+                    version="1">
+                    <threshold>0</threshold>
+                    <labels>
+                        <label_should_show />
+                        <label_should_not_show />
+                    </labels>
+                </data>
+            </instance>
+
+            <bind nodeset="/data/labels/label_should_show" relevant="/data/threshold = 0" />
+            <bind nodeset="/data/labels/label_should_not_show" relevant="/data/threshold &lt; 0" />
+
+            <itext>
+                <translation lang="English" default="">
+                    <text id="visible-label">
+                        <value>This label should be visible</value>
+                    </text>
+                    <text id="invisible-label">
+                        <value>This label should NOT be visible</value>
+                    </text>
+                </translation>
+            </itext>
+
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/labels" appearance="field-list">
+            <trigger ref="/data/labels/label_should_show" appearance="minimal">
+                <label ref="jr:itext('visible-label')" />
+            </trigger>
+            <trigger ref="/data/labels/label_should_not_show" appearance="minimal">
+                <label ref="jr:itext('invisible-label')" />
+            </trigger>
+        </group>
+    </h:body>
+</h:html>

--- a/core/src/test/resources/xform_tests/test_display_conditions_regression.xml
+++ b/core/src/test/resources/xform_tests/test_display_conditions_regression.xml
@@ -19,10 +19,10 @@
 
             <!--
              Below are two binds with identical conditions modulo the operator
-             (=, <). They are mutually ex There was a bug where the operator
-             wasn't being taken into account in `equals` method.  This form
-             tests for that these mutually exclusive conditions are treated
-             distinctly ensuring that only one label appears.
+             (=, <). There was a bug where the operator wasn't being taken into
+             account in `equals` method.  This form tests for that these
+             mutually exclusive conditions are treated distinctly ensuring that
+             only one label appears.
             -->
             <bind nodeset="/data/labels/label_should_show" relevant="/data/threshold = 0" />
             <bind nodeset="/data/labels/label_should_not_show" relevant="/data/threshold &lt; 0" />

--- a/core/src/test/resources/xform_tests/test_display_conditions_regression.xml
+++ b/core/src/test/resources/xform_tests/test_display_conditions_regression.xml
@@ -17,6 +17,13 @@
                 </data>
             </instance>
 
+            <!--
+             Below are two binds with identical conditions modulo the operator
+             (=, <). They are mutually ex There was a bug where the operator
+             wasn't being taken into account in `equals` method.  This form
+             tests for that these mutually exclusive conditions are treated
+             distinctly ensuring that only one label appears.
+            -->
             <bind nodeset="/data/labels/label_should_show" relevant="/data/threshold = 0" />
             <bind nodeset="/data/labels/label_should_not_show" relevant="/data/threshold &lt; 0" />
 


### PR DESCRIPTION
Fix for binary operation expression equality bug introduced in  https://github.com/dimagi/javarosa/pull/168 where two different operation classes, like equality and comparative, could be equal if they had the same sub-expressions and operator number encoding.

Basically, 'a < b' and 'a = b' were being treated as the same triggerable condition.

Addresses this ticket http://manage.dimagi.com/default.asp?222850