### PR TITLE
Fix for IText Calculations not properly initializing with the app locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ j2me/javarosa-app/tools/pyAntTasks-1.3.jar
 util/schema-gen/lib/xpp3-1.1.4.jar
 util/validator/org.javarosa.shellformtest/tools/
 util/validator/org.javarosa.xform.validator/JavaRosaFormTest.jar
+
+# gradle
+.gradle/**

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1501,7 +1501,20 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
      * @param newInstance true if the form is to be used for a new entry interaction,
      *                    false if it is using an existing IDataModel
      */
+
     public void initialize(boolean newInstance, InstanceInitializationFactory factory) {
+        initialize(newInstance, factory, null);
+    }
+
+    /**
+     * meant to be called after deserialization and initialization of handlers
+     *
+     * @param newInstance true if the form is to be used for a new entry interaction,
+     *                    false if it is using an existing IDataModel
+     * @param locale The default locale in the current environment, if provided. Can be null
+     *               to rely on the form's internal default.
+     */
+    public void initialize(boolean newInstance, InstanceInitializationFactory factory, String locale) {
         for (Enumeration en = formInstances.keys(); en.hasMoreElements(); ) {
             String instanceId = (String)en.nextElement();
             DataInstance instance = formInstances.get(instanceId);
@@ -1512,8 +1525,14 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
             preloadInstance(mainInstance.getRoot());
         }
 
-        if (getLocalizer() != null && getLocalizer().getLocale() == null) {
-            getLocalizer().setToDefault();
+        if (getLocalizer() != null) {
+            if(locale == null || !getLocalizer().hasLocale(locale)) {
+                if(getLocalizer().getLocale() == null) {
+                    getLocalizer().setToDefault();
+                }
+            } else {
+                getLocalizer().setLocale(locale);
+            }
         }
 
         if (newInstance) {

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1538,13 +1538,13 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
     }
 
     private void initLocale(String locale) {
-        if (getLocalizer() != null) {
-            if (locale == null || !getLocalizer().hasLocale(locale)) {
-                if (getLocalizer().getLocale() == null) {
-                    getLocalizer().setToDefault();
+        if (localizer != null) {
+            if (locale == null || !localizer.hasLocale(locale)) {
+                if (localizer.getLocale() == null) {
+                    localizer.setToDefault();
                 }
             } else {
-                getLocalizer().setLocale(locale);
+                localizer.setLocale(locale);
             }
         }
     }

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1525,15 +1525,7 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
             preloadInstance(mainInstance.getRoot());
         }
 
-        if (getLocalizer() != null) {
-            if(locale == null || !getLocalizer().hasLocale(locale)) {
-                if(getLocalizer().getLocale() == null) {
-                    getLocalizer().setToDefault();
-                }
-            } else {
-                getLocalizer().setLocale(locale);
-            }
-        }
+        initLocale(locale);
 
         if (newInstance) {
             // only dispatch on a form's first opening, not subsequent loadings
@@ -1543,6 +1535,18 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
         }
 
         initAllTriggerables();
+    }
+
+    private void initLocale(String locale) {
+        if (getLocalizer() != null) {
+            if (locale == null || !getLocalizer().hasLocale(locale)) {
+                if (getLocalizer().getLocale() == null) {
+                    getLocalizer().setToDefault();
+                }
+            } else {
+                getLocalizer().setLocale(locale);
+            }
+        }
     }
 
     /**

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -410,9 +410,7 @@ public class FormDefTest {
     @Test
     public void testITextXPathFunction() throws XPathSyntaxException {
         FormParseInit fpi = new FormParseInit("/xform_tests/itext_function.xml");
-        FormEntryController fec =  initFormEntry(fpi);
-
-        fec.setLanguage("new");
+        FormEntryController fec =  initFormEntry(fpi, "new");
 
         boolean inlinePassed = false;
         boolean nestedPassed = false;
@@ -451,9 +449,14 @@ public class FormDefTest {
         } while (fec.stepToNextEvent() != FormEntryController.EVENT_END_OF_FORM);
     }
 
+
     private static FormEntryController initFormEntry(FormParseInit fpi) {
+        return initFormEntry(fpi, null);
+    }
+
+    private static FormEntryController initFormEntry(FormParseInit fpi, String locale) {
         FormEntryController fec = fpi.getFormEntryController();
-        fpi.getFormDef().initialize(true, null);
+        fpi.getFormDef().initialize(true, null, locale);
         fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
         return fec;
     }

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -435,12 +435,13 @@ public class FormDefTest {
 
 
     /**
-     * Regression: IText function in xpath was not properly using the current locale instead of the
-     * backup
+     * Regression: IText function in xpath was not properly using the current
+     * locale instead of the default
      */
     @Test
     public void testITextXPathFunction() throws XPathSyntaxException {
         FormParseInit fpi = new FormParseInit("/xform_tests/itext_function.xml");
+        // init form with the 'new' locale instead of the default 'old' locale
         FormEntryController fec =  initFormEntry(fpi, "new");
 
         boolean inlinePassed = false;

--- a/core/src/test/resources/xform_tests/itext_function.xml
+++ b/core/src/test/resources/xform_tests/itext_function.xml
@@ -1,8 +1,8 @@
 <h:html xmlns:h="http://www.w3.org/1999/xhtml"
-        xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns="http://www.w3.org/2002/xforms"
         xmlns:jr="http://openrosa.org/javarosa">
     <h:head>
-        <h:title>Constraints for simple and select answers</h:title>
+        <h:title>Form for use in checking form init with non-default locale works</h:title>
         <model>
             <instance>
                 <data

--- a/core/src/test/resources/xform_tests/itext_function.xml
+++ b/core/src/test/resources/xform_tests/itext_function.xml
@@ -1,0 +1,48 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>Constraints for simple and select answers</h:title>
+        <model>
+            <instance>
+                <data
+                    xmlns="http://openrosa.org/tests/itextfunction"
+                    uiVersion="1" version="279" name="Itext Function">
+                    <calculation/>
+                    <inline/>
+                    <nested/>
+                </data>
+            </instance>
+
+            <bind nodeset="/data/calculation" calculate="jr:itext('text_val')"/>
+
+            <itext>
+                <translation lang="old" default="">
+                    <text id="text_val">
+                        <value>wrong</value>
+                    </text>
+                    <text id="question_text">
+                        <value><output value="jr:itext('text_val')"/></value>
+                    </text>
+                </translation>
+                <translation lang="new">
+                    <text id="text_val">
+                        <value>right</value>
+                    </text>
+                    <text id="question_text">
+                        <value><output value="jr:itext('text_val')"/></value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+
+    <h:body>
+        <trigger ref="inline">
+            <label><output value="jr:itext('text_val')"/></label>
+        </trigger>
+        <trigger ref="nested">
+            <label ref="jr:itext('question_text')"/>
+        </trigger>
+    </h:body>
+</h:html>

--- a/util/schema-gen/src/org/javarosa/engine/XFormEnvironment.java
+++ b/util/schema-gen/src/org/javarosa/engine/XFormEnvironment.java
@@ -29,6 +29,8 @@ public class XFormEnvironment {
 
     private final FormDef form;
 
+    private String preferredLocale;
+
     private FormEntryModel fem;
     private FormEntryController fec;
 
@@ -63,7 +65,7 @@ public class XFormEnvironment {
     public FormEntryController setup(InstanceInitializationFactory factory) {
         form.setEvaluationContext(getEC());
 
-        form.initialize(true, factory);
+        form.initialize(true, factory, preferredLocale);
 
         if(recording) {
             session = new Session();
@@ -107,7 +109,7 @@ public class XFormEnvironment {
     public void setLocale(String locale) {
         for(String existingLocale : this.form.getLocalizer().getAvailableLocales()) {
             if(existingLocale.equals(locale)) {
-                this.form.getLocalizer().setLocale(locale);
+                preferredLocale = locale;
                 return;
             }
         }


### PR DESCRIPTION
Fix for bugs where the itext calculation in xpath was always using the form's default locale, even if the app locale is different.

Needed for ICDS

Fogbugz:
http://manage.dimagi.com/?221785

cross-request: https://github.com/dimagi/commcare-odk/pull/1200