### PR TITLE
Make validator write unicode output

### DIFF
--- a/util/schema-gen/src/org/javarosa/xform/schema/Harness.java
+++ b/util/schema-gen/src/org/javarosa/xform/schema/Harness.java
@@ -77,7 +77,7 @@ public class Harness {
             try {
                 xfp.start(leftOverArgs[1]);
             } catch (FileNotFoundException e) {
-                System.out.println("File not found at " + args[0]+ "!!!!");
+                System.out.println("File not found at " + args[0] + "!!!!");
             }
 
         } else {
@@ -208,10 +208,16 @@ public class Harness {
                 System.exit(1);
             }
         }
-        PrintStream responseStream = System.out;
+        PrintStream defaultOutStream = System.out;
+        PrintStream responseStream;
         // Redirect output to syserr because sysout is being used for the
         // response, and must be kept clean.
-        System.setOut(System.err);
+        try {
+            responseStream = new PrintStream(System.err, false, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            responseStream = System.err;
+        }
+        System.setOut(responseStream);
 
         InputStreamReader isr;
         try {
@@ -250,7 +256,7 @@ public class Harness {
             try {
                 isr.close();
                 // reset output stream on exit
-                System.setOut(responseStream);
+                System.setOut(defaultOutStream);
             } catch (IOException e) {
                 System.err.println("IO Exception while closing stream.");
                 e.printStackTrace();
@@ -376,8 +382,14 @@ public class Harness {
     private static FormDef loadFormDef(String[] args) {
         // Redirect output to syserr because sysout is being used for the
         // response, and must be kept clean.
-        PrintStream responseStream = System.out;
-        System.setOut(System.err);
+        PrintStream defaultOutStream = System.out;
+        PrintStream responseStream;
+        try {
+            responseStream = new PrintStream(System.err, false, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            responseStream = System.err;
+        }
+        System.setOut(responseStream);
 
         InputStream inputStream = System.in;
 
@@ -396,7 +408,7 @@ public class Harness {
         FormDef form = XFormUtils.getFormFromInputStream(inputStream);
 
         // reset the system output on exit.
-        System.setOut(responseStream);
+        System.setOut(defaultOutStream);
 
         return form;
     }

--- a/util/schema-gen/src/org/javarosa/xform/schema/JSONReporter.java
+++ b/util/schema-gen/src/org/javarosa/xform/schema/JSONReporter.java
@@ -41,9 +41,6 @@ public class JSONReporter extends XFormParserReporter {
         this.failureReason = e.getMessage();
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.xform.parse.XFormParserReporter#warning(java.lang.String, java.lang.String, java.lang.String)
-     */
     @Override
     public void warning(String type, String message, String xmlLocation) {
         JSONObject problem = new JSONObject();
@@ -56,9 +53,6 @@ public class JSONReporter extends XFormParserReporter {
         problems.add(problem);
     }
 
-    /* (non-Javadoc)
-     * @see org.javarosa.xform.parse.XFormParserReporter#error(java.lang.String)
-     */
     @Override
     public void error(String message) {
         JSONObject problem = new JSONObject();


### PR DESCRIPTION
Make the form_translate jar output UTF-8 when possible. This will make error messages with unicode more helpful on HQ.

Instead of seeing `?????` in the image below, we will see real unicode
![2016-05-06-101354_2400x1920_scrot](https://cloud.githubusercontent.com/assets/94817/15077903/999f1a6a-137e-11e6-90ba-d960d199c6b3.png)

Changes `form_translate.jar validate` output from:
```
{"problems":[],"fatal_error":"Invalid XPath in value set action declaration: '??????'\n    Problem found at nodeset: \/html\/head\/model\/setvalue\n    With element <setvalue event=\"xforms-ready\" ref=\"\/data\/emoji_list\/question3\" value=\"??????\"\/>\n","fatal_error_expected":true,"validated":false}
```
to
```
{"problems":[],"fatal_error":"Invalid XPath in value set action declaration: 'हिन्दी'\n    Problem found at nodeset: \/html\/head\/model\/setvalue\n    With element <setvalue event=\"xforms-ready\" ref=\"\/data\/emoji_list\/question3\" value=\"हिन्दी\"\/>\n","fatal_error_expected":true,"validated":false}
```

Fix for this ticket: http://manage.dimagi.com/default.asp?113905

@millerdev: might find it nice to see a 2 year old ticket getting closed out