### PR TITLE
Tell user when CommCare's unable to save unsupported unicode

### DIFF
--- a/core/src/main/java/org/javarosa/xform/util/XFormSerializer.java
+++ b/core/src/main/java/org/javarosa/xform/util/XFormSerializer.java
@@ -3,6 +3,7 @@ package org.javarosa.xform.util;
 import org.kxml2.io.KXmlSerializer;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
+import org.xmlpull.v1.XmlSerializer;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -56,18 +57,36 @@ public class XFormSerializer {
      * Formats an XML document into a UTF-8 (no BOM) compatible format
      *
      * @return The raw bytes of the utf-8 encoded doc
-     * @throws IOException If there is an issue transferring the bytes to a byte stream.
-     * @throws UnsupportedEncodingException If the document contains values that are not UTF-8
-     * encoded.
+     * @throws IOException                           If there is an issue transferring
+     *                                               the bytes to a byte stream.
+     * @throws UnsupportedUnicodeSurrogatesException If the document contains values
+     *                                               that are not UTF-8 encoded.
      */
     public static byte[] getUtfBytesFromDocument(Document doc) throws IOException {
-        KXmlSerializer serializer = new KXmlSerializer();
+        KXmlSerializer serializer = new KXmlSerializer() {
+            @Override
+            public XmlSerializer text(String text) throws IOException {
+                try {
+                    return super.text(text);
+                } catch (IllegalArgumentException e) {
+                    // certain versions of Android have trouble encoding
+                    // unicode characters that require "surrogates".
+                    throw new UnsupportedUnicodeSurrogatesException(text);
+                }
+            }
+        };
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         Writer osw = new OutputStreamWriter(bos, "UTF-8");
         serializer.setOutput(osw);
         doc.write(serializer);
         serializer.flush();
         return bos.toByteArray();
+    }
+
+    public static class UnsupportedUnicodeSurrogatesException extends RuntimeException {
+        public UnsupportedUnicodeSurrogatesException(String message) {
+            super(message);
+        }
     }
 
 }


### PR DESCRIPTION
Unicode characters that require "surrogates" will cause form saving to crash on certain older devices ([thanks for the 'fix' google](https://code.google.com/p/android/issues/detail?id=64108)).

Catch these exceptions and rethrow in a manner that can be shown to the user in an actionable way. Either the user inputted that character, or the form builder did; in both cases, showing them this will allow them to react accordingly