### PR TITLE
Tell user when `replace` uses bad regexp

### DIFF
--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -1040,7 +1040,13 @@ public class XPathFuncExpr extends XPathExpression {
      */
     private String replace(Object o1, Object o2, Object o3) {
         String source = toString(o1);
-        RE pattern = new RE(toString(o2));
+        String regexString = toString(o2);
+        RE pattern;
+        try {
+            pattern = new RE(regexString);
+        } catch (RESyntaxException e) {
+            throw new XPathException("The regular expression '" + regexString + "' is invalid.");
+        }
         String replacement = toString(o3);
         return pattern.subst(source, replacement);
     }


### PR DESCRIPTION
Show the user an error when they use a bad regexp in a `replace` xpath expression, like 
 `replace("abbc", "a(.*c", "$1")`

![screen](https://cloud.githubusercontent.com/assets/94817/15277270/ed495f18-1acc-11e6-8368-8022bfea99f7.png)
