### PR TITLE
Use (much faster) built-in String.split() method when possible

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/data/GeoPointData.java
+++ b/core/src/main/java/org/javarosa/core/model/data/GeoPointData.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.model.data;
 
 import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
@@ -115,8 +116,8 @@ public class GeoPointData implements IAnswerData {
     public GeoPointData cast(UncastData data) throws IllegalArgumentException {
         double[] ret = new double[4];
 
-        Vector<String> choices = DateUtils.split(data.value, " ", true);
-        if (choices.size() < 2) {
+        String[] choices = DataUtil.splitOnSpaces(data.value);
+        if (choices.length < 2) {
             throw new IllegalArgumentException("Fewer than two coordinates provided");
         }
 

--- a/core/src/main/java/org/javarosa/core/model/data/SelectMultiData.java
+++ b/core/src/main/java/org/javarosa/core/model/data/SelectMultiData.java
@@ -2,6 +2,7 @@ package org.javarosa.core.model.data;
 
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.ExtWrapList;
@@ -128,8 +129,7 @@ public class SelectMultiData implements IAnswerData {
 
     public SelectMultiData cast(UncastData data) throws IllegalArgumentException {
         Vector v = new Vector();
-
-        Vector<String> choices = DateUtils.split(data.value, " ", true);
+        String[] choices = DataUtil.splitOnSpaces(data.value);
         for (String s : choices) {
             v.addElement(new Selection(s));
         }

--- a/core/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/core/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -745,8 +745,7 @@ public class DateUtils {
      * @param delimiter                 The delimeter to be used
      * @param combineMultipleDelimiters If two delimiters occur in a row,
      *                                  remove the empty strings created by their split
-     * @return An array of strings contained in original which were
-     * seperated by the delimeter
+     * @return A vector of strings contained in original which were separated by the delimiter
      */
     public static Vector<String> split(String str, String delimiter, boolean combineMultipleDelimiters) {
         Vector<String> pieces = new Vector<String>();

--- a/core/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/core/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -740,40 +740,6 @@ public class DateUtils {
     /* ==== UTILITY ==== */
 
     /**
-     * Tokenizes a string based on the given delimiter string
-     *
-     * @param str                       The string to be split
-     * @param delimiter                 The delimeter to be used
-     * @param combineMultipleDelimiters If two delimiters occur in a row,
-     *                                  remove the empty strings created by their split
-     * @return A vector of strings contained in original which were separated by the delimiter
-     */
-    public static Vector<String> split(String str, String delimiter, boolean combineMultipleDelimiters) {
-        Vector<String> pieces = new Vector<String>();
-
-        int index = str.indexOf(delimiter);
-        // add all substrings, split by delimiter, to pieces.
-        while (index >= 0) {
-            pieces.addElement(str.substring(0, index));
-            str = str.substring(index + delimiter.length());
-            index = str.indexOf(delimiter);
-        }
-        pieces.addElement(str);
-
-        // remove all pieces that are empty string
-        if (combineMultipleDelimiters) {
-            for (int i = 0; i < pieces.size(); i++) {
-                if (pieces.elementAt(i).length() == 0) {
-                    pieces.removeElementAt(i);
-                    i--;
-                }
-            }
-        }
-
-        return pieces;
-    }
-
-    /**
      * Converts an integer to a string, ensuring that the string
      * contains a certain number of digits
      *

--- a/core/src/main/java/org/javarosa/core/model/utils/DateUtils.java
+++ b/core/src/main/java/org/javarosa/core/model/utils/DateUtils.java
@@ -1,6 +1,7 @@
 package org.javarosa.core.model.utils;
 
 import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.MathUtils;
 
 import java.util.Calendar;
@@ -374,15 +375,15 @@ public class DateUtils {
      * @return Was the string successfully parsed into a valid date
      */
     private static boolean parseDateAndStore(String dateStr, DateFields df) {
-        Vector pieces = split(dateStr, "-", false);
-        if (pieces.size() != 3) {
+        String[] pieces = DataUtil.splitOnDash(dateStr);
+        if (pieces.length != 3) {
             return false;
         }
 
         try {
-            df.year = Integer.parseInt((String)pieces.elementAt(0));
-            df.month = Integer.parseInt((String)pieces.elementAt(1));
-            df.day = Integer.parseInt((String)pieces.elementAt(2));
+            df.year = Integer.parseInt(pieces[0]);
+            df.month = Integer.parseInt(pieces[1]);
+            df.day = Integer.parseInt(pieces[2]);
         } catch (NumberFormatException nfe) {
             return false;
         }
@@ -412,27 +413,27 @@ public class DateUtils {
         } else if (timeStr.indexOf("+") != -1 || timeStr.indexOf("-") != -1) {
             timeOffset = new DateFields();
 
-            Vector<String> pieces = split(timeStr, "+", false);
+            String[] pieces = DataUtil.splitOnPlus(timeStr);
 
             // We're going to add the Offset straight up to get UTC
             // so we need to invert the sign on the offset string
             int offsetSign = -1;
 
-            if (pieces.size() > 1) {
+            if (pieces.length > 1) {
                 // offsetSign is already correct
             } else {
-                pieces = split(timeStr, "-", false);
+                pieces = DataUtil.splitOnDash(timeStr);
                 offsetSign = 1;
             }
 
-            timeStr = pieces.elementAt(0);
+            timeStr = pieces[0];
 
-            String offset = pieces.elementAt(1);
+            String offset = pieces[1];
             String hours = offset;
             if (offset.indexOf(":") != -1) {
-                Vector<String> tzPieces = split(offset, ":", false);
-                hours = tzPieces.elementAt(0);
-                int mins = Integer.parseInt(tzPieces.elementAt(1));
+                String[] tzPieces = DataUtil.splitOnColon(offset);
+                hours = tzPieces[0];
+                int mins = Integer.parseInt(tzPieces[1]);
                 timeOffset.minute = mins * offsetSign;
             }
             timeOffset.hour = Integer.parseInt(hours) * offsetSign;
@@ -481,19 +482,19 @@ public class DateUtils {
      * @return Was the string successfully interpreted as valid time?
      */
     private static boolean parseRawTime(String timeStr, DateFields df) {
-        Vector pieces = split(timeStr, ":", false);
+        String[] pieces = DataUtil.splitOnColon(timeStr);
 
-        if (pieces.size() != 2 && pieces.size() != 3) {
+        if (pieces.length != 2 && pieces.length != 3) {
             return false;
         }
 
         try {
-            df.hour = Integer.parseInt((String)pieces.elementAt(0));
-            df.minute = Integer.parseInt((String)pieces.elementAt(1));
+            df.hour = Integer.parseInt(pieces[0]);
+            df.minute = Integer.parseInt(pieces[1]);
 
             // if seconds part present, parse it
-            if (pieces.size() == 3) {
-                String secStr = (String)pieces.elementAt(2);
+            if (pieces.length == 3) {
+                String secStr = pieces[2];
                 int i;
                 // only grab prefix of seconds piece that includes digits and decimal(s)
                 for (i = 0; i < secStr.length(); i++) {

--- a/core/src/main/java/org/javarosa/core/model/utils/QuestionPreloader.java
+++ b/core/src/main/java/org/javarosa/core/model/utils/QuestionPreloader.java
@@ -22,6 +22,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.services.PropertyManager;
+import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.Map;
 import org.javarosa.core.util.PropertyUtils;
 
@@ -195,10 +196,7 @@ public class QuestionPreloader {
         if (preloadParams.equals("today")) {
             d = new Date();
         } else if (preloadParams.substring(0, 11).equals("prevperiod-")) {
-            Vector v = DateUtils.split(preloadParams.substring(11), "-", false);
-            String[] params = new String[v.size()];
-            for (int i = 0; i < params.length; i++)
-                params[i] = (String)v.elementAt(i);
+            String[] params = DataUtil.splitOnDash(preloadParams.substring(11));
 
             try {
                 String type = params[0];

--- a/core/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/core/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -82,24 +82,58 @@ public class DataUtil {
     public static class StringSplitter {
 
         public String[] splitOnSpaces(String s) {
-            Vector<String> vectorSplit = DateUtils.split(s, " ", true);
+            Vector<String> vectorSplit = split(s, " ", true);
             return vectorSplit.toArray(new String[vectorSplit.size()]);
         }
 
         public String[] splitOnDash(String s) {
-            Vector<String> vectorSplit = DateUtils.split(s, "-", false);
+            Vector<String> vectorSplit = split(s, "-", false);
             return vectorSplit.toArray(new String[vectorSplit.size()]);
         }
 
         public String[] splitOnColon(String s) {
-            Vector<String> vectorSplit = DateUtils.split(s, ":", false);
+            Vector<String> vectorSplit = split(s, ":", false);
             return vectorSplit.toArray(new String[vectorSplit.size()]);
         }
 
         public String[] splitOnPlus(String s) {
-            Vector<String> vectorSplit = DateUtils.split(s, "+", false);
+            Vector<String> vectorSplit = split(s, "+", false);
             return vectorSplit.toArray(new String[vectorSplit.size()]);
         }
+    }
+
+    /**
+     * Tokenizes a string based on the given delimiter string
+     *
+     * @param str                       The string to be split
+     * @param delimiter                 The delimeter to be used
+     * @param combineMultipleDelimiters If two delimiters occur in a row,
+     *                                  remove the empty strings created by their split
+     * @return A vector of strings contained in original which were separated by the delimiter
+     */
+    private static Vector<String> split(String str, String delimiter, boolean combineMultipleDelimiters) {
+        Vector<String> pieces = new Vector<String>();
+
+        int index = str.indexOf(delimiter);
+        // add all substrings, split by delimiter, to pieces.
+        while (index >= 0) {
+            pieces.addElement(str.substring(0, index));
+            str = str.substring(index + delimiter.length());
+            index = str.indexOf(delimiter);
+        }
+        pieces.addElement(str);
+
+        // remove all pieces that are empty string
+        if (combineMultipleDelimiters) {
+            for (int i = 0; i < pieces.size(); i++) {
+                if (pieces.elementAt(i).length() == 0) {
+                    pieces.removeElementAt(i);
+                    i--;
+                }
+            }
+        }
+
+        return pieces;
     }
 
 }

--- a/core/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/core/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -103,7 +103,8 @@ public class DataUtil {
     }
 
     /**
-     * Tokenizes a string based on the given delimiter string
+     * Custom implementation of tokenizing a string based on a delimiter, for use in j2me
+     * (Java's String.split() method was not available until Java 1.4)
      *
      * @param str                       The string to be split
      * @param delimiter                 The delimeter to be used

--- a/core/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/core/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -1,5 +1,7 @@
 package org.javarosa.core.util;
 
+import org.javarosa.core.model.utils.DateUtils;
+
 import java.util.Vector;
 
 /**
@@ -12,6 +14,7 @@ public class DataUtil {
     static Integer[] iarray;
 
     static UnionLambda unionLambda = new UnionLambda();
+    static StringSplitter stringSplitter = new StringSplitter();
 
     /**
      * Get Integer object that corresponds to int argument from a
@@ -55,4 +58,20 @@ public class DataUtil {
             return u;
         }
     }
+
+    public static String[] splitOnSpaces(String s) {
+        return stringSplitter.splitOnSpaces(s);
+    }
+
+    public static void setStringSplitter(StringSplitter newStringSplitter) {
+        stringSplitter = newStringSplitter;
+    }
+
+    public static class StringSplitter {
+        public String[] splitOnSpaces(String s) {
+            Vector<String> vectorSplit = DateUtils.split(s, " ", true);
+            return vectorSplit.toArray(new String[vectorSplit.size()]);
+        }
+    }
+
 }

--- a/core/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/core/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -63,13 +63,41 @@ public class DataUtil {
         return stringSplitter.splitOnSpaces(s);
     }
 
+    public static String[] splitOnDash(String s) {
+        return stringSplitter.splitOnDash(s);
+    }
+
+    public static String[] splitOnColon(String s) {
+        return stringSplitter.splitOnColon(s);
+    }
+
+    public static String[] splitOnPlus(String s) {
+        return stringSplitter.splitOnPlus(s);
+    }
+
     public static void setStringSplitter(StringSplitter newStringSplitter) {
         stringSplitter = newStringSplitter;
     }
 
     public static class StringSplitter {
+
         public String[] splitOnSpaces(String s) {
             Vector<String> vectorSplit = DateUtils.split(s, " ", true);
+            return vectorSplit.toArray(new String[vectorSplit.size()]);
+        }
+
+        public String[] splitOnDash(String s) {
+            Vector<String> vectorSplit = DateUtils.split(s, "-", false);
+            return vectorSplit.toArray(new String[vectorSplit.size()]);
+        }
+
+        public String[] splitOnColon(String s) {
+            Vector<String> vectorSplit = DateUtils.split(s, ":", false);
+            return vectorSplit.toArray(new String[vectorSplit.size()]);
+        }
+
+        public String[] splitOnPlus(String s) {
+            Vector<String> vectorSplit = DateUtils.split(s, "+", false);
             return vectorSplit.toArray(new String[vectorSplit.size()]);
         }
     }

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -867,7 +867,7 @@ public class XPathFuncExpr extends XPathExpression {
         }
 
         String s = (String)evalResult;
-        return new Double(DateUtils.split(s, " ", true).size());
+        return new Double(DataUtil.splitOnSpaces(s).length);
     }
 
     /**

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -10,6 +10,7 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.GeoPointUtils;
 import org.javarosa.core.util.CacheTable;
+import org.javarosa.core.util.DataUtil;
 import org.javarosa.core.util.MathUtils;
 import org.javarosa.core.util.PropertyUtils;
 import org.javarosa.core.util.externalizable.DeserializationException;
@@ -879,7 +880,7 @@ public class XPathFuncExpr extends XPathExpression {
         String selection = (String)unpack(o1);
         int index = toInt(o2).intValue();
 
-        String[] entries = selection.split("[ ]+");
+        String[] entries = DataUtil.splitOnSpaces(selection);
 
         if (entries.length <= index) {
             throw new XPathException("Attempting to select element " + index +

--- a/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
+++ b/core/src/main/java/org/javarosa/xpath/expr/XPathFuncExpr.java
@@ -879,13 +879,13 @@ public class XPathFuncExpr extends XPathExpression {
         String selection = (String)unpack(o1);
         int index = toInt(o2).intValue();
 
-        Vector<String> entries = DateUtils.split(selection, " ", true);
+        String[] entries = selection.split("[ ]+");
 
-        if (entries.size() <= index) {
+        if (entries.length <= index) {
             throw new XPathException("Attempting to select element " + index +
-                    " of a list with only " + entries.size() + " elements.");
+                    " of a list with only " + entries.length + " elements.");
         } else {
-            return entries.elementAt(index);
+            return entries[index];
         }
     }
 


### PR DESCRIPTION
As part of performance improvements for ICDS Daily Feeding Form: Using built in String.split() method instead of DateUtils.split() improves form load time with a case load of 400 from 1 min 40 seconds to 27 seconds