### PR TITLE
fix j2me method calls

### DIFF
--- a/core/src/main/java/org/javarosa/core/util/DataUtil.java
+++ b/core/src/main/java/org/javarosa/core/util/DataUtil.java
@@ -112,7 +112,7 @@ public class DataUtil {
      *                                  remove the empty strings created by their split
      * @return A vector of strings contained in original which were separated by the delimiter
      */
-    private static Vector<String> split(String str, String delimiter, boolean combineMultipleDelimiters) {
+    public static Vector<String> split(String str, String delimiter, boolean combineMultipleDelimiters) {
         Vector<String> pieces = new Vector<String>();
 
         int index = str.indexOf(delimiter);

--- a/j2me/communication/src/org/javarosa/service/transport/securehttp/HttpAuthenticator.java
+++ b/j2me/communication/src/org/javarosa/service/transport/securehttp/HttpAuthenticator.java
@@ -132,7 +132,7 @@ public class HttpAuthenticator {
         if(!params.containsKey("qop")) {
             qop = DigestAuthResponse.QOP_UNSPECIFIED;
         } else {
-            Vector<String> qops = DateUtils.split(params.get("qop"),",",false);
+            Vector<String> qops = DataUtil.split(params.get("qop"),",",false);
             if(qops.contains(DigestAuthResponse.QOP_AUTH_INT) && qops.contains(DigestAuthResponse.QOP_AUTH)) {
                 //choose between auth-int and auth if both are available;
                 qop = DigestAuthResponse.QOP_AUTH;

--- a/j2me/core/src/org/javarosa/j2me/file/J2meFileReference.java
+++ b/j2me/core/src/org/javarosa/j2me/file/J2meFileReference.java
@@ -174,7 +174,7 @@ public class J2meFileReference implements Reference
 
             //Don't let anything try to touch this connector while we're manipulating it, since the URI won't be correct.
             synchronized (connections) {
-                Vector<String> pieces = DateUtils.split(connector.getPath(), "/", true);
+                Vector<String> pieces = DataUtil.split(connector.getPath(), "/", true);
                 FileConnection walker = null;
 
                 String fileName = "file:///" + pieces.elementAt(0) + "/";

--- a/j2me/form-entry/src/org/javarosa/utilities/media/MediaUtils.java
+++ b/j2me/form-entry/src/org/javarosa/utilities/media/MediaUtils.java
@@ -160,7 +160,7 @@ public class MediaUtils {
             }
             if (!"".equals(action)) {
                 try {
-                    Vector<String> pieces = DateUtils.split(uri, "/", false);
+                    Vector<String> pieces = DataUtil.split(uri, "/", false);
                     uri = pieces.lastElement();
                 } catch (Exception e) {
                     // just use the full URI

--- a/j2me/javarosa-app/src/org/javarosa/demo/applogic/JRDemoContext.java
+++ b/j2me/javarosa-app/src/org/javarosa/demo/applogic/JRDemoContext.java
@@ -98,7 +98,7 @@ public class JRDemoContext {
     }
 
     private void parseAndProcessLanguageResources(String resourceString) {
-        Vector<String> resources = DateUtils.split(resourceString, ",", true);
+        Vector<String> resources = DataUtil.split(resourceString, ",", true);
         for(int i = 0 ; i < resources.size() ; i+=2) {
             String langkey = resources.elementAt(i);
             String resource = resources.elementAt(i+1);

--- a/j2me/objects/org.javarosa.user/src/org/javarosa/user/view/LoginForm.java
+++ b/j2me/objects/org.javarosa.user/src/org/javarosa/user/view/LoginForm.java
@@ -285,7 +285,7 @@ public class LoginForm extends FramedForm {
     private boolean checkPassword(String stored, String input) {
         if(stored.indexOf("$") != -1) {
             String alg = "sha1";
-            String salt = (String)DateUtils.split(stored,"$", false).elementAt(1);
+            String salt = (String)DataUtil.split(stored,"$", false).elementAt(1);
             String hashed = SHA1.encodeHex(salt + input);
             String compare = alg + "$" + salt + "$" + hashed;
 


### PR DESCRIPTION
Fix build failure caused by https://github.com/dimagi/javarosa/pull/304 (I forgot to check for method usage in the j2me code). I'm not bothering to have any of the j2me code paths use the `StringSplitter` logic because we know they will always just call the j2me implementation.