### PR TITLE
Repeat delete fix

### DIFF
--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -360,9 +360,24 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
         TreeReference parentRef = deleteRef.getParentRef();
         TreeElement parentElement = mainInstance.resolveReference(parentRef);
 
-        int childMult = deleteElement.getMult();
         parentElement.removeChild(deleteElement);
 
+        reduceTreeSiblingMultiplicities(parentElement, deleteElement);
+
+        this.getMainInstance().cleanCache();
+
+        triggerTriggerables(deleteRef);
+        return newIndex;
+    }
+
+    /**
+     * When a repeat is deleted, we need to reduce the multiplicities of its siblings that were higher than it
+     * by one.
+     * @param parentElement the parent of the deleted element
+     * @param deleteElement the deleted element
+     */
+    private void reduceTreeSiblingMultiplicities(TreeElement parentElement, TreeElement deleteElement){
+        int childMult = deleteElement.getMult();
         // update multiplicities of other child nodes
         for (int i = 0; i < parentElement.getNumChildren(); i++) {
             TreeElement child = parentElement.getChildAt(i);
@@ -372,11 +387,6 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
                 child.setMult(child.getMult() - 1);
             }
         }
-
-        this.getMainInstance().cleanCache();
-
-        triggerTriggerables(deleteRef);
-        return newIndex;
     }
 
     public void createNewRepeat(FormIndex index) throws InvalidReferenceException {

--- a/core/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/core/src/main/java/org/javarosa/core/model/FormDef.java
@@ -366,7 +366,9 @@ public class FormDef implements IFormElement, Persistable, IMetaData,
         // update multiplicities of other child nodes
         for (int i = 0; i < parentElement.getNumChildren(); i++) {
             TreeElement child = parentElement.getChildAt(i);
-            if (child.getMult() > childMult) {
+            // We also need to check that this element matches the deleted element (besides multiplicity)
+            // in the case where the deleted repeat's parent isn't a subgroup
+            if (child.doFieldsMatch(deleteElement) && child.getMult() > childMult) {
                 child.setMult(child.getMult() - 1);
             }
         }

--- a/core/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/core/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -920,6 +920,25 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         return TreeUtilities.tryBatchChildFetch(this, mChildStepMapping, name, mult, predicates, evalContext);
     }
 
+    // Return true if these elements are the same EXCEPT for their multiplicity (IE are members of the same repeat)
+    public boolean doFieldsMatch(TreeElement otherTreeElement){
+        return (name.equals(otherTreeElement.name) &&
+                flags == otherTreeElement.flags &&
+                dataType == otherTreeElement.dataType &&
+                ((instanceName != null && instanceName.equals(otherTreeElement.instanceName)) ||
+                        (instanceName == null && otherTreeElement.instanceName == null)) &&
+                ((constraint != null && constraint.equals(otherTreeElement.constraint)) ||
+                        (constraint == null && otherTreeElement.constraint == null)) &&
+                ((preloadHandler != null && preloadHandler.equals(otherTreeElement.preloadHandler)) ||
+                        (preloadHandler == null && otherTreeElement.preloadHandler == null)) &&
+                ((preloadParams != null && preloadParams.equals(otherTreeElement.preloadParams)) ||
+                        (preloadParams == null && otherTreeElement.preloadParams == null)) &&
+                ((namespace != null && namespace.equals(otherTreeElement.namespace)) ||
+                        (namespace == null && otherTreeElement.namespace == null)) &&
+                ((value != null && value.uncast().getString().equals(otherTreeElement.value.uncast().getString())) ||
+                        value == null && otherTreeElement.value == null));
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -930,22 +949,8 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         // trickery to avoid looping indefinitely
         if (o instanceof TreeElement) {
             TreeElement otherTreeElement = (TreeElement)o;
-            final boolean doFieldsMatch = (name.equals(otherTreeElement.name) &&
-                    multiplicity == otherTreeElement.multiplicity &&
-                    flags == otherTreeElement.flags &&
-                    dataType == otherTreeElement.dataType &&
-                    ((instanceName != null && instanceName.equals(otherTreeElement.instanceName)) ||
-                            (instanceName == null && otherTreeElement.instanceName == null)) &&
-                    ((constraint != null && constraint.equals(otherTreeElement.constraint)) ||
-                            (constraint == null && otherTreeElement.constraint == null)) &&
-                    ((preloadHandler != null && preloadHandler.equals(otherTreeElement.preloadHandler)) ||
-                            (preloadHandler == null && otherTreeElement.preloadHandler == null)) &&
-                    ((preloadParams != null && preloadParams.equals(otherTreeElement.preloadParams)) ||
-                            (preloadParams == null && otherTreeElement.preloadParams == null)) &&
-                    ((namespace != null && namespace.equals(otherTreeElement.namespace)) ||
-                            (namespace == null && otherTreeElement.namespace == null)) &&
-                    ((value != null && value.uncast().getString().equals(otherTreeElement.value.uncast().getString())) ||
-                            value == null && otherTreeElement.value == null));
+            final boolean doFieldsMatch = doFieldsMatch(otherTreeElement) &&
+                    multiplicity == otherTreeElement.multiplicity;
             if (doFieldsMatch) {
                 if (children != null) {
                     if (otherTreeElement.children == null) {

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -477,19 +477,19 @@ public class FormDefTest {
         TreeElement root = fpi.getFormDef().getInstance().getRoot();
 
         // confirm both groups have two iterations and second iteration is set
-        assert root.getChildMultiplicity("question4") == 2;
-        assert root.getChild("question4", 1) != null;
-        assert root.getChildMultiplicity("question1") == 2;
-        assert root.getChild("question1", 1) != null;
+        assertTrue(root.getChildMultiplicity("question4") == 2);
+        assertTrue(root.getChild("question4", 1) != null);
+        assertTrue(root.getChildMultiplicity("question1") == 20;
+        assertTrue(root.getChild("question1", 1) != null);
 
         fec.deleteRepeat(0);
 
         // Confirm that the deleted repeat is gone and its sibling's multiplicity reduced
-        assert root.getChildMultiplicity("question4") == 1;
-        assert root.getChild("question4", 1) == null;
+        assertTrue(root.getChildMultiplicity("question4") == 1);
+        assertTrue(root.getChild("question4", 1) == null);
         // Confirm that the other repeat is unchanged
-        assert root.getChildMultiplicity("question1") == 2;
-        assert root.getChild("question1", 1) != null;
+        assertTrue(root.getChildMultiplicity("question1") == 2);
+        assertTrue(root.getChild("question1", 1) != null);
     }
 
     /**

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -31,9 +31,9 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Vector;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.javarosa.xform.parse.XFormParser;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Phillip Mates (pmates@dimagi.com)
@@ -477,19 +477,19 @@ public class FormDefTest {
         TreeElement root = fpi.getFormDef().getInstance().getRoot();
 
         // confirm both groups have two iterations and second iteration is set
-        assertTrue(root.getChildMultiplicity("question4") == 2);
-        assertTrue(root.getChild("question4", 1) != null);
-        assertTrue(root.getChildMultiplicity("question1") == 20;
-        assertTrue(root.getChild("question1", 1) != null);
+        assertEquals(root.getChildMultiplicity("question4"), 2);
+        assertNotEquals(root.getChild("question4", 1), null);
+        assertEquals(root.getChildMultiplicity("question1"), 2);
+        assertNotEquals(root.getChild("question1", 1), null);
 
         fec.deleteRepeat(0);
 
         // Confirm that the deleted repeat is gone and its sibling's multiplicity reduced
-        assertTrue(root.getChildMultiplicity("question4") == 1);
-        assertTrue(root.getChild("question4", 1) == null);
+        assertEquals(root.getChildMultiplicity("question4"), 1);
+        assertEquals(root.getChild("question4", 1), null);
         // Confirm that the other repeat is unchanged
-        assertTrue(root.getChildMultiplicity("question1") == 2);
-        assertTrue(root.getChild("question1", 1) != null);
+        assertEquals(root.getChildMultiplicity("question1"), 2);
+        assertNotEquals(root.getChild("question1", 1), null);
     }
 
     /**
@@ -509,13 +509,13 @@ public class FormDefTest {
             TreeReference currentRef = fec.getModel().getFormIndex().getReference();
             if(currentRef == null) { continue; }
             if(currentRef.genericize().toString().equals("/data/inline")) {
-                Assert.assertEquals("Inline IText Method Callout", "right",
+                assertEquals("Inline IText Method Callout", "right",
                         fec.getModel().getCaptionPrompt().getQuestionText());
                 inlinePassed = true;
             }
 
             if(currentRef.genericize().toString().equals("/data/nested")) {
-                Assert.assertEquals("Nexted IText Method Callout", "right",
+                assertEquals("Nexted IText Method Callout", "right",
                         fec.getModel().getCaptionPrompt().getQuestionText());
                 nestedPassed = true;
             }

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -11,6 +11,7 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.instance.test.DummyInstanceInitializationFactory;
 import org.javarosa.core.model.utils.test.PersistableSandbox;
@@ -28,6 +29,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Vector;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -470,8 +472,16 @@ public class FormDefTest {
         fec.answerQuestion(new StringData("Repeat 4/2"));
         fec.stepToPreviousEvent();
         fec.stepToPreviousEvent();
+
         fec.deleteRepeat(0);
-        new XFormSerializingVisitor().serializeInstance(fpi.getFormDef().getInstance());
+        TreeElement root = fpi.getFormDef().getInstance().getRoot();
+
+        // Confirm that the deleted repeat is gone and its sibling's multiplicity reduced
+        assert root.getChildMultiplicity("question4") == 1;
+        assert root.getChild("question1", 4) == null;
+        // Confirm that the other repeat is unchanged
+        assert root.getChildMultiplicity("question1") == 2;
+        assert root.getChild("question1", 1) != null;
     }
 
     /**

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -16,16 +16,22 @@ import org.javarosa.core.model.instance.test.DummyInstanceInitializationFactory;
 import org.javarosa.core.model.utils.test.PersistableSandbox;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.form.api.FormEntryController;
+import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.test_utils.ExprEvalUtils;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.Calendar;
 import java.util.Date;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import org.javarosa.xform.parse.XFormParser;
 
 /**
  * @author Phillip Mates (pmates@dimagi.com)
@@ -432,7 +438,40 @@ public class FormDefTest {
         }
     }
 
-
+    @Test
+    public void testDeleteRepeatMultiplicities() throws IOException {
+        FormParseInit fpi = new FormParseInit("/multiple_repeats.xml");
+        FormEntryController fec = initFormEntry(fpi, "en");
+        fec.stepToNextEvent();
+        fec.newRepeat();
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Repeat 1/1"));
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Repeat 1/2"));
+        fec.stepToNextEvent();
+        fec.newRepeat();
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Repeat 2/1"));
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Repeat 2/2"));
+        fec.stepToNextEvent();
+        fec.stepToNextEvent();
+        fec.newRepeat();
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Repeat 3/1"));
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Repeat 3/2"));
+        fec.stepToNextEvent();
+        fec.newRepeat();
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Repeat 4/1"));
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Repeat 4/2"));
+        fec.stepToPreviousEvent();
+        fec.stepToPreviousEvent();
+        fec.deleteRepeat(0);
+        new XFormSerializingVisitor().serializeInstance(fpi.getFormDef().getInstance());
+    }
 
     /**
      * Regression: IText function in xpath was not properly using the current
@@ -491,5 +530,22 @@ public class FormDefTest {
         fpi.getFormDef().initialize(true, null, locale);
         fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
         return fec;
+    }
+
+    String readFile(String fileName) throws IOException {
+        BufferedReader br = new BufferedReader(new FileReader(fileName));
+        try {
+            StringBuilder sb = new StringBuilder();
+            String line = br.readLine();
+
+            while (line != null) {
+                sb.append(line);
+                sb.append("\n");
+                line = br.readLine();
+            }
+            return sb.toString();
+        } finally {
+            br.close();
+        }
     }
 }

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -438,6 +438,7 @@ public class FormDefTest {
         }
     }
 
+    // regression test for when we weren't decrementing multiplicities correctly when repeats were deleted
     @Test
     public void testDeleteRepeatMultiplicities() throws IOException {
         FormParseInit fpi = new FormParseInit("/multiple_repeats.xml");

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -448,37 +448,45 @@ public class FormDefTest {
         fec.stepToNextEvent();
         fec.newRepeat();
         fec.stepToNextEvent();
-        fec.answerQuestion(new StringData("Repeat 1/1"));
+        fec.answerQuestion(new StringData("First repeat, first iteration: question2"));
         fec.stepToNextEvent();
-        fec.answerQuestion(new StringData("Repeat 1/2"));
-        fec.stepToNextEvent();
-        fec.newRepeat();
-        fec.stepToNextEvent();
-        fec.answerQuestion(new StringData("Repeat 2/1"));
-        fec.stepToNextEvent();
-        fec.answerQuestion(new StringData("Repeat 2/2"));
-        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("First repeat, first iteration: question3"));
         fec.stepToNextEvent();
         fec.newRepeat();
         fec.stepToNextEvent();
-        fec.answerQuestion(new StringData("Repeat 3/1"));
+        fec.answerQuestion(new StringData("First repeat, second iteration: question2"));
         fec.stepToNextEvent();
-        fec.answerQuestion(new StringData("Repeat 3/2"));
+        fec.answerQuestion(new StringData("First repeat, second iteration: question3"));
+        fec.stepToNextEvent();
+        fec.stepToNextEvent();
+        // moving from first repeat (question1) to second (question4)
+        fec.newRepeat();
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Second repeat, first iteration: question5"));
+        fec.stepToNextEvent();
+        fec.answerQuestion(new StringData("Second repeat, first iteration: question6"));
         fec.stepToNextEvent();
         fec.newRepeat();
         fec.stepToNextEvent();
-        fec.answerQuestion(new StringData("Repeat 4/1"));
+        fec.answerQuestion(new StringData("Second repeat, second iteration: question5"));
         fec.stepToNextEvent();
-        fec.answerQuestion(new StringData("Repeat 4/2"));
+        fec.answerQuestion(new StringData("Second repeat, second iteration: question6"));
         fec.stepToPreviousEvent();
         fec.stepToPreviousEvent();
 
-        fec.deleteRepeat(0);
         TreeElement root = fpi.getFormDef().getInstance().getRoot();
+
+        // confirm both groups have two iterations and second iteration is set
+        assert root.getChildMultiplicity("question4") == 2;
+        assert root.getChild("question4", 1) != null;
+        assert root.getChildMultiplicity("question1") == 2;
+        assert root.getChild("question1", 1) != null;
+
+        fec.deleteRepeat(0);
 
         // Confirm that the deleted repeat is gone and its sibling's multiplicity reduced
         assert root.getChildMultiplicity("question4") == 1;
-        assert root.getChild("question1", 4) == null;
+        assert root.getChild("question4", 1) == null;
         // Confirm that the other repeat is unchanged
         assert root.getChildMultiplicity("question1") == 2;
         assert root.getChild("question1", 1) != null;

--- a/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
+++ b/core/src/test/java/org/javarosa/core/model/test/FormDefTest.java
@@ -532,21 +532,4 @@ public class FormDefTest {
         fec.jumpToIndex(FormIndex.createBeginningOfFormIndex());
         return fec;
     }
-
-    String readFile(String fileName) throws IOException {
-        BufferedReader br = new BufferedReader(new FileReader(fileName));
-        try {
-            StringBuilder sb = new StringBuilder();
-            String line = br.readLine();
-
-            while (line != null) {
-                sb.append(line);
-                sb.append("\n");
-                line = br.readLine();
-            }
-            return sb.toString();
-        } finally {
-            br.close();
-        }
-    }
 }

--- a/core/src/test/resources/multiple_repeats.xml
+++ b/core/src/test/resources/multiple_repeats.xml
@@ -1,0 +1,72 @@
+
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>Untitled Form</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/16732A09-88C5-4C73-99E7-704CC27200B1" uiVersion="1" version="3" name="Untitled Form">
+                    <question1 jr:template="">
+                        <question2/>
+                        <question3/>
+                    </question1>
+                    <question4 jr:template="">
+                        <question5/>
+                        <question6/>
+                    </question4>
+                    <orx:meta xmlns:cc="http://commcarehq.org/xforms"><orx:deviceID/><orx:timeStart/><orx:timeEnd/><orx:username/><orx:userID/><orx:instanceID/><cc:appVersion/></orx:meta></data>
+            </instance>
+            <bind nodeset="/data/question1"/>
+            <bind nodeset="/data/question1/question2" type="xsd:string"/>
+            <bind nodeset="/data/question1/question3" type="xsd:string"/>
+            <bind nodeset="/data/question4"/>
+            <bind nodeset="/data/question4/question5" type="xsd:string"/>
+            <bind nodeset="/data/question4/question6" type="xsd:string"/>
+            <itext>
+                <translation lang="en" default="">
+                    <text id="question1-label">
+                        <value>question1</value>
+                    </text>
+                    <text id="question1/question2-label">
+                        <value>question2</value>
+                    </text>
+                    <text id="question1/question3-label">
+                        <value>question3</value>
+                    </text>
+                    <text id="question4-label">
+                        <value>question4</value>
+                    </text>
+                    <text id="question4/question5-label">
+                        <value>question5</value>
+                    </text>
+                    <text id="question4/question6-label">
+                        <value>question6</value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+        <group>
+            <label ref="jr:itext('question1-label')"/>
+            <repeat nodeset="/data/question1">
+                <input ref="/data/question1/question2">
+                    <label ref="jr:itext('question1/question2-label')"/>
+                </input>
+                <input ref="/data/question1/question3">
+                    <label ref="jr:itext('question1/question3-label')"/>
+                </input>
+            </repeat>
+        </group>
+        <group>
+            <label ref="jr:itext('question4-label')"/>
+            <repeat nodeset="/data/question4">
+                <input ref="/data/question4/question5">
+                    <label ref="jr:itext('question4/question5-label')"/>
+                </input>
+                <input ref="/data/question4/question6">
+                    <label ref="jr:itext('question4/question6-label')"/>
+                </input>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Fix for: http://manage.dimagi.com/default.asp?229136

Appears that this has been broken for a while, but is (obviously) a very rare situation. Essentially, when an element was deleted we were grabbing all of its parent's children then iterating through these and reducing the multiplicity if they exceeded a certain threshold. This works fine when a repeat is within a group or there are no other repeats, but when (as in this case) the repeat's parent element has other repeat elements as children AND these children's multiplicities exceed the threshold, then we incorrectly reduce the multiplicities. The solution is to check that the deleted node and the child nodes are the "same" in every sense except multiplicity. 

This fix is admittedly very inelegant, but since the needed functionality is basically the equals function minus the multiplicity check I couldn't think of a prettier way to do it.

This should get into 2.28 so we can release the new TF jars. 